### PR TITLE
Improved debugging / console messages for ps6000 scope detection

### DIFF
--- a/lib/picoscope_6000_impl.cc
+++ b/lib/picoscope_6000_impl.cc
@@ -444,23 +444,19 @@ namespace gr {
       // Required to force sequence execution of open unit calls...
       boost::mutex::scoped_lock init_guard(g_init_mutex);
 
-      while(status != PICO_NOT_FOUND)
-      {
+      while(status != PICO_NOT_FOUND) {
           status = ps6000OpenUnit(&(temp_handles[devCount]),NULL);
           if(status == PICO_OK || status == PICO_USB3_0_DEVICE_NON_USB3_0_PORT)
               devCount++;
       }
 
-      if (devCount == 0)
-      {
+      if (devCount == 0) {
           GR_LOG_ERROR(d_logger, "No ps6000 device found");
           return make_pico_6000_error_code(12);
       }
 
-      if( d_serial_number.empty() )
-      {
-          if( devCount != 1)
-          {
+      if( d_serial_number.empty() ) {
+          if( devCount != 1) {
               GR_LOG_ERROR(d_logger, "There is more than one ps6000 connected. Please enter a serial!");
               for(uint16_t i = 0; i< devCount; i++)
                   ps6000CloseUnit(temp_handles[i]);
@@ -469,56 +465,32 @@ namespace gr {
       }
       else
       {
-          for(uint16_t i = 0; i< devCount; i++)
-          {
+          GR_LOG_INFO(d_logger, "Searching for scope with serial: '" + d_serial_number + "'");
+          bool found = false;
+          for(uint16_t i = 0; i< devCount; i++) {
               int16_t requiredSize = 20;
               int8_t serial[requiredSize];
 
               ps6000GetUnitInfo(temp_handles[i], serial, sizeof (serial), &requiredSize, PICO_BATCH_AND_SERIAL);
-              std::cout << "serial: " << serial << std::endl;
-
               std::ostringstream convert;
-              for (int a = 0; serial[a] != int8_t('\0'); a++) {
+              for(int a = 0; serial[a] != int8_t('\0'); a++) {
                   convert << serial[a];
               }
-              if( convert.str() == d_serial_number )
-              {
-                  std::cout << "Device Found: " << convert.str() << std::endl;
+              GR_LOG_INFO(d_logger, "... found scope with serial: '" + convert.str() + "'");
+              if(convert.str() == d_serial_number) {
+                  found = true;
                   d_handle = temp_handles[i];
               }
-              else
-              {
-                  std::cout << "Device Skipped: " << convert.str() << std::endl;
+              else {
                   ps6000CloseUnit(temp_handles[i]);
               }
           }
+
+          if(found)
+              GR_LOG_INFO(d_logger, "Serials match, scope '" + d_serial_number + "' found.");
+          else
+              GR_LOG_ERROR(d_logger, "No matching serial found for scope '" + d_serial_number + "'");
       }
-
-      //exit(1);
-      //std::cout << "picoscope_6000_impl::driver_initialize 1" << std::endl;
-      //std::cout << "d_serial_number: " << d_serial_number <<  std::endl;
-      // take any if serial number is not provided (useful for testing purposes)
-
-
-//      if (d_serial_number.empty()) {
-//        status = ps6000OpenUnit(&(d_handle), NULL);
-//      }
-//      else {
-////        int8_t serial[20];
-////        size_t index = 0;
-////        for(; index < d_serial_number.size(); index++ )
-////        {
-////            serial[index] = d_serial_number[index];
-////        }
-////        serial[index] = int8_t('\0');
-////        std::cout << "serial:" << serial << std::endl;
-//        status = ps6000OpenUnit(&(d_handle), (int8_t*)d_serial_number.c_str());
-//      }
-//      std::cout << "picoscope_6000_impl::driver_initialize 2" << std::endl;
-//      if (status != PICO_OK) {
-//        GR_LOG_ERROR(d_logger, "open unit failed: " + ps6000_get_error_message(status));
-//        return make_pico_6000_error_code(status);
-//      }
 
       // maximum value is used for conversion to volts
       d_max_value = PS6000_MAX_VALUE;


### PR DESCRIPTION
Just a small modification to more clearly show which serial is searched for and which serials were found.

- Increased readibilty of info messages
- 'sucess' message when ps6000 is found
- Usage of GR_LOG_INFO
- style fixes