### PR TITLE
Thread AUX trigger as analog Trigger

### DIFF
--- a/grc/digitizers_picoscope_6000.xml
+++ b/grc/digitizers_picoscope_6000.xml
@@ -14,11 +14,8 @@ self.$(id).set_aichan('C', $enable_ai_c, $range_ai_c, $coupling_ai_c, $offset_ai
 self.$(id).set_aichan('D', $enable_ai_d, $range_ai_d, $coupling_ai_d, $offset_ai_d)
 
 if $trigger_source != 'None':
-    if $trigger_source == 'AUX':
-        self.$(id).set_di_trigger($pin_number, $trigger_direction)
-    else:
-        self.$(id).set_aichan_trigger($trigger_source, $trigger_direction, $trigger_threshold)
-        
+    self.$(id).set_aichan_trigger($trigger_source, $trigger_direction, $trigger_threshold)
+
 if $acquisition_mode == 'Streaming':
     self.$(id).set_buffer_size($buff_size)
     self.$(id).set_nr_buffers($nr_buffers)

--- a/lib/digitizer_block_impl.cc
+++ b/lib/digitizer_block_impl.cc
@@ -465,7 +465,9 @@ namespace gr {
    void
    digitizer_block_impl::set_aichan_trigger(const std::string &id, trigger_direction_t direction, double threshold)
    {
-     convert_to_aichan_idx(id); // Just to verify id
+     // Some scopes have an dedicated AUX Trigger-Input. Skip id verification for them
+     if (id != "AUX")
+       convert_to_aichan_idx(id); // Just to verify id
 
      d_trigger_settings.source = id;
      d_trigger_settings.threshold = threshold;


### PR DESCRIPTION
So far the AUX input of the ps6000 was threat like a digital input.

Surprisingly that often worked well. but has issues (Looks like it used a threashold of 0V)
E.g. when mutible ps6000 are triggered via the same trigger source, some 'magic' is going on which lets the second scope trigger delayed.

This patch fixes the problem my threading the AUX trigger as an analog trigger. According to the programmer-manual it has a Range of +/-1V. (Raw-value calculation for the trigger threashold anyhow was broken, since it did not consider the channel range)

