### PR TITLE
Draft: Fix trigger threshold calculation for all scopes

### DIFF
--- a/lib/digitizer_block_impl.cc
+++ b/lib/digitizer_block_impl.cc
@@ -454,6 +454,16 @@ namespace gr {
      return count;
    }
 
+   double
+   digitizer_block_impl::get_aichan_range(const std::string &id) const
+   {
+     if (id != "AUX")
+         return 1.; // AUX triger input has a fixed Range of +/- 1V
+
+     auto idx = convert_to_aichan_idx(id);
+     return d_channel_settings[idx].range;
+   }
+
    void
    digitizer_block_impl::set_aichan_range(const std::string &id, double range, double range_offset)
    {

--- a/lib/digitizer_block_impl.h
+++ b/lib/digitizer_block_impl.h
@@ -278,6 +278,8 @@ namespace gr {
        */
       int get_enabled_aichan_count() const;
 
+      double get_aichan_range(const std::string &id) const;
+
       void set_aichan_range(const std::string &id, double range, double range_offset = 0) override;
 
       void set_aichan_trigger(const std::string &id, trigger_direction_t direction, double threshold) override;

--- a/lib/picoscope_3000a_impl.cc
+++ b/lib/picoscope_3000a_impl.cc
@@ -584,17 +584,10 @@ namespace gr {
       if (d_trigger_settings.is_analog()
               && d_acquisition_mode == acquisition_mode_t::RAPID_BLOCK)
       {
-        int16_t PS3000A_MAX_VALUE;
-        status = ps3000aMaximumValue(d_handle, &PS3000A_MAX_VALUE);
-        if(status != PICO_OK) {
-          GR_LOG_ERROR(d_logger, "ps3000aMaximumValue: " + ps3000a_get_error_message(status));
-          return make_pico_3000a_error_code(status);
-        }
-
         status = ps3000aSetSimpleTrigger(d_handle,
               true,  // enable
               convert_to_ps3000a_channel(d_trigger_settings.source),
-              convert_voltage_to_ps3000a_raw_adc_count(d_trigger_settings.threshold, get_aichan_range(d_trigger_settings.source), PS3000A_MAX_VALUE),
+              convert_voltage_to_ps3000a_raw_adc_count(d_trigger_settings.threshold, get_aichan_range(d_trigger_settings.source), d_max_value),
               convert_to_ps3000a_threshold_direction(d_trigger_settings.direction),
               0,     // delay
              -1);    // auto trigger

--- a/lib/picoscope_4000a_impl.cc
+++ b/lib/picoscope_4000a_impl.cc
@@ -500,17 +500,10 @@ namespace gr {
       if (d_trigger_settings.is_analog()
             && d_acquisition_mode == acquisition_mode_t::RAPID_BLOCK)
       {
-        int16_t PS4000A_MAX_VALUE;
-        status = ps4000aMaximumValue(d_handle, &PS4000A_MAX_VALUE);
-        if(status != PICO_OK) {
-          GR_LOG_ERROR(d_logger, "ps3000aMaximumValue: " + ps4000a_get_error_message(status));
-          return make_pico_4000a_error_code(status);
-        }
-
         status = ps4000aSetSimpleTrigger(d_handle,
               true,  // enable
               convert_to_ps4000a_channel(d_trigger_settings.source),
-              convert_voltage_to_ps4000a_raw_adc_count(d_trigger_settings.threshold, get_aichan_range(d_trigger_settings.source), PS4000A_MAX_VALUE),
+              convert_voltage_to_ps4000a_raw_adc_count(d_trigger_settings.threshold, get_aichan_range(d_trigger_settings.source), d_max_value),
               convert_to_ps4000a_threshold_direction(d_trigger_settings.direction),
               0,     // delay
              -1);    // auto trigger

--- a/lib/picoscope_6000_impl.cc
+++ b/lib/picoscope_6000_impl.cc
@@ -298,7 +298,7 @@ namespace gr {
     };
 
     int16_t
-    convert_voltage_to_ps6000_raw_logic_value(double voltage, float channel_range)
+    convert_voltage_to_ps6000_raw_adc_count(double voltage, float channel_range)
     {
       if (fabs(voltage) > double (fabs(channel_range))) {
           std::ostringstream message;
@@ -534,28 +534,10 @@ namespace gr {
       if (d_trigger_settings.is_enabled()
              && d_acquisition_mode == acquisition_mode_t::RAPID_BLOCK)
       {
-        float channel_range;
-        if (d_trigger_settings.source == "A")
-            channel_range = d_channel_settings[0].range;
-        else if (d_trigger_settings.source == "B")
-            channel_range = d_channel_settings[1].range;
-        else if (d_trigger_settings.source == "C")
-            channel_range = d_channel_settings[2].range;
-        else if (d_trigger_settings.source == "D")
-            channel_range = d_channel_settings[3].range;
-        else if (d_trigger_settings.source == "AUX")
-            channel_range = 1.; // AUX can only be used for triggering, has a fixed Range of +/-1V according to Programmers guideline
-        else {
-            std::ostringstream message;
-            message << "Exception in " << __FILE__ << ":" << __LINE__ << ": Invalid Channel Name: " << d_trigger_settings.source;
-            GR_LOG_ERROR(d_logger, message.str());
-            return make_pico_6000_error_code(status);
-        }
-
         status = ps6000SetSimpleTrigger(d_handle,
               true,  // enable
               convert_to_ps6000_channel(d_trigger_settings.source),
-              convert_voltage_to_ps6000_raw_logic_value(d_trigger_settings.threshold, channel_range),
+              convert_voltage_to_ps6000_raw_adc_count(d_trigger_settings.threshold, get_aichan_range(d_trigger_settings.source)),
               convert_to_ps6000_threshold_direction(d_trigger_settings.direction),
               0,     // delay
              -1);    // auto trigger


### PR DESCRIPTION
The old calculation assumed that +5V always matches PSXXXX_MAX_VALUE,
however that is only the case for the ps3000 digital inputs.

On all analog inputs, the values which matches PSXXXX_MAX_VALUE depends on
the according range of the channel (ADC count)

(On AUX, the range is fixed to +/- 1V)

(This already was fixed for ps6000 in https://github.com/fair-acc/gr-digitizers/pull/86)

"Draft", because the changes build fine, but first need to be tested on all scope-types (check required voltage to actually trigger)

References (Check for method psXXXXSetSimpleTrigger ):
https://www.picotech.com/download/manuals/picoscope-4000-series-a-api-programmers-guide.pdf
https://www.picotech.com/download/manuals/PicoScope3000SeriesAApiProgrammersGuide.pdf
https://www.picotech.com/download/manuals/picoscope-6000-series-programmers-guide.pdf