### PR TITLE
Add "BUFFERS_LOST" information into status of acq_info tag

### DIFF
--- a/include/digitizers/status.h
+++ b/include/digitizers/status.h
@@ -25,8 +25,11 @@ namespace digitizers {
        // Not enough pre- or post-trigger samples available to perform realignment or/and user delay.
        CHANNEL_STATUS_REALIGNMENT_ERROR = 0x02,
 
-       // Insufficient buffer size to extract all samples
-       CHANNEL_STATUS_NOT_ALL_DATA_EXTRACTED = 0x04,
+       // Insufficient buffer size to extract all samples / some samples got lost.
+       // This might happen when when the selected number of buffers/buffer-size on the Digitizer is to small.
+       // This as well might happen when the digitizer block is not called with sufficient frequency,
+       // (e.g. Due to slow data processing blocks which cause a "traffic jam" in the flowgraph)
+       CHANNEL_STATUS_DATA_BUFFERS_LOST= 0x04,
 
        CHANNEL_STATUS_TIMEOUT_WAITING_WR_OR_REALIGNMENT_EVENT = 0x08
     };

--- a/lib/picoscope_impl.cc
+++ b/lib/picoscope_impl.cc
@@ -222,11 +222,14 @@ namespace gr {
           d_tmp_buffer->d_status.resize(get_enabled_aichan_count());
 
           for (auto i = 0; i < get_enabled_aichan_count(); i++) {
+            d_tmp_buffer->d_status[i] = 0;
+
             if (overflow & (1 << i)) {
-              d_tmp_buffer->d_status[i] = channel_status_t::CHANNEL_STATUS_OVERFLOW;
+              d_tmp_buffer->d_status[i] |= channel_status_t::CHANNEL_STATUS_OVERFLOW;
             }
-            else {
-              d_tmp_buffer->d_status[i] = 0;
+
+            if (d_tmp_buffer->d_lost_count > 0) {
+              d_tmp_buffer->d_status[i] |= channel_status_t::CHANNEL_STATUS_DATA_BUFFERS_LOST;
             }
           }
 


### PR DESCRIPTION
Required in FESA (cannot match WR-events to trigger tags when trigger tags are possibly are missing)

Tested on dal007 (4x ps4000 system) ... already helped me to find a good buffer size