### PR TITLE
Replace boost sleep methods by std sleep methods

### DIFF
--- a/lib/digitizer_block_impl.cc
+++ b/lib/digitizer_block_impl.cc
@@ -912,7 +912,7 @@ namespace gr {
    digitizer_block_impl::poll_work_function()
    {
      boost::unique_lock<boost::mutex> lock(d_poller_mutex, boost::defer_lock);
-     auto poll_rate = boost::chrono::microseconds((long)(d_poll_rate * 1000000));
+     auto poll_rate = std::chrono::microseconds((long)(d_poll_rate * 1000000));
 
      gr::thread::set_thread_name(pthread_self(), "poller");
 
@@ -934,7 +934,7 @@ namespace gr {
 
        if (state == poller_state_t::RUNNING) {
          // Start watchdog a new
-         auto poll_start = boost::chrono::high_resolution_clock::now();
+         auto poll_start = std::chrono::high_resolution_clock::now();
          auto ec = driver_poll();
          if (ec) {
            // Only print out an error message
@@ -967,9 +967,8 @@ namespace gr {
            d_app_buffer.notify_data_ready(digitizer_block_errc::Watchdog);
 
          }
-         boost::chrono::duration<float> poll_duration = boost::chrono::high_resolution_clock::now() - poll_start;
-
-         boost::this_thread::sleep_for(poll_rate - poll_duration);
+         std::chrono::duration<float> poll_duration = std::chrono::high_resolution_clock::now() - poll_start;
+         std::this_thread::sleep_for(poll_rate - poll_duration);
        }
        else {
          if (state == poller_state_t::PEND_IDLE) {
@@ -989,7 +988,7 @@ namespace gr {
          }
 
          // Relax CPU
-         boost::this_thread::sleep_for(boost::chrono::microseconds(100));
+         std::this_thread::sleep_for(std::chrono::milliseconds(100));
        }
      }
    }

--- a/lib/digitizer_block_impl.cc
+++ b/lib/digitizer_block_impl.cc
@@ -912,7 +912,7 @@ namespace gr {
    digitizer_block_impl::poll_work_function()
    {
      boost::unique_lock<boost::mutex> lock(d_poller_mutex, boost::defer_lock);
-     auto poll_duration = std::chrono::microseconds((long)(d_poll_rate * 1000000));
+     std::chrono::duration<float> poll_duration(d_poll_rate);
 
      gr::thread::set_thread_name(pthread_self(), "poller");
 

--- a/lib/digitizer_block_impl.cc
+++ b/lib/digitizer_block_impl.cc
@@ -988,7 +988,7 @@ namespace gr {
          }
 
          // Relax CPU
-         std::this_thread::sleep_for(std::chrono::milliseconds(100));
+         std::this_thread::sleep_for(std::chrono::microseconds(100));
        }
      }
    }

--- a/lib/digitizer_block_impl.cc
+++ b/lib/digitizer_block_impl.cc
@@ -970,16 +970,14 @@ namespace gr {
          }
 
          // Substract the time each iteration itself took in order to get closer to the desired poll duration
-         std::chrono::duration<float> poll_duration_correction = std::chrono::high_resolution_clock::now() - poll_start;
-         if(poll_duration_correction > poll_duration)
-         {
-             sleep_time = std::chrono::duration<float>::zero();
-             GR_LOG_WARN(d_logger, "Watchdog: Poll rate is set too low (" + std::to_string(d_poll_rate) + "s) "
+         std::chrono::duration<float> remaining_poll_duration = std::chrono::high_resolution_clock::now() - poll_start;
+         if(remaining_poll_duration > poll_duration) {
+           sleep_time = std::chrono::duration<float>::zero();
+           GR_LOG_WARN(d_logger, "Watchdog: Poll rate is set too low (" + std::to_string(d_poll_rate) + "s) "
                                    "Cannot ensure that the Digitizer block work method will be called within that rate.");
          }
-         else
-         {
-             sleep_time = poll_duration - poll_duration_correction;
+         else {
+           sleep_time = poll_duration - remaining_poll_duration;
          }
          std::this_thread::sleep_for(sleep_time);
        }

--- a/lib/digitizer_block_impl.cc
+++ b/lib/digitizer_block_impl.cc
@@ -912,7 +912,7 @@ namespace gr {
    digitizer_block_impl::poll_work_function()
    {
      boost::unique_lock<boost::mutex> lock(d_poller_mutex, boost::defer_lock);
-     auto poll_rate = std::chrono::microseconds((long)(d_poll_rate * 1000000));
+     auto poll_duration = std::chrono::microseconds((long)(d_poll_rate * 1000000));
 
      gr::thread::set_thread_name(pthread_self(), "poller");
 
@@ -967,8 +967,10 @@ namespace gr {
            d_app_buffer.notify_data_ready(digitizer_block_errc::Watchdog);
 
          }
-         std::chrono::duration<float> poll_duration = std::chrono::high_resolution_clock::now() - poll_start;
-         std::this_thread::sleep_for(poll_rate - poll_duration);
+
+         // Substract the time each iteration itself took in order to get closer to the desired poll duration
+         std::chrono::duration<float> poll_duration_correction = std::chrono::high_resolution_clock::now() - poll_start;
+         std::this_thread::sleep_for(poll_duration - poll_duration_correction);
        }
        else {
          if (state == poller_state_t::PEND_IDLE) {


### PR DESCRIPTION
I was just debugging something else, than it happened out of nothing: The Digitizer does not deliver any data any more directly after startup.

Using directly the pico4000 raw driver still worked. I remeber I saw that effect before and it was gone after a reboot. 
First I tried to revert my changes .. did not help. The effect seems to be heree to stay.

So this time I tracked it down instead of rebooting, and found out that the method `boost::this_thread::sleep_for(boost::chrono::microseconds(100));` does not return control for unknown reason. (Hey, thats supposed to be just a nanosleep :disappointed: )

Replacing the boost methods with` std::` equivalents fixed the issue.