### PR TITLE
Decimate and adjust timebase: Simplify tag propagation

### DIFF
--- a/lib/decimate_and_adjust_timebase_impl.cc
+++ b/lib/decimate_and_adjust_timebase_impl.cc
@@ -51,13 +51,10 @@ namespace gr {
       // add tags with corrected offset to the output stream
       std::vector<gr::tag_t> tags;
       get_tags_in_range(tags, 0, samp0_count, samp0_count + input_items.size());
-      for (const auto &tag : tags){
-          tag_t new_tag = tag;
-          if(decimation() != 0)
-              new_tag.offset = uint64_t(tag.offset / decimation());
-          else
-              new_tag.offset = uint64_t(tag.offset);
-          add_item_tag(0, new_tag);
+      for (auto &tag : tags){
+        if(decimation() != 0)
+          tag.offset = uint64_t(tag.offset / decimation());
+        add_item_tag(0, tag);
       }
 
       return noutput_items;

--- a/lib/decimate_and_adjust_timebase_impl.cc
+++ b/lib/decimate_and_adjust_timebase_impl.cc
@@ -46,51 +46,19 @@ namespace gr {
         gr_vector_const_void_star &input_items,
         gr_vector_void_star &output_items)
     {
-      const auto decim = decimation();
+      const auto samp0_count = nitems_read(0);
 
-      float *out = (float *) output_items[0];
-      const float *in = (const float *) input_items[0];
-
-      int i_in = 0, i_out = 0;
-      for(; i_out < noutput_items; i_out++)
-      {
-        // Keep one in N functionality
-        out[i_out] = in[i_in];
-
-        std::vector<gr::tag_t> tags;
-        get_tags_in_range(tags, 0, nitems_read(0) + i_in, nitems_read(0) + i_in + decim );
-        // required to merge acq_infotags due to this bug: https://github.com/gnuradio/gnuradio/issues/2364
-        // otherwise we will eat to much memory
-        // TODO: Fix bug in gnuradio (https://gitlab.com/al.schwinn/gr-digitizers/issues/33)
-        acq_info_t merged_acq_info;
-        merged_acq_info.status = 0;
-        bool found_acq_info = false;
-        for(auto tag : tags)
-        {
-            //std::cout << "tag found: " << tag.key << std::endl;
-            if(tag.key == pmt::string_to_symbol(trigger_tag_name))
-            {
-                trigger_t trigger_tag_data = decode_trigger_tag(tag);
-                add_item_tag(0, make_trigger_tag(trigger_tag_data, nitems_written(0) + i_out));
-                //std::cout << "trigger tag added" << std::endl;
-            }
-            else if(tag.key == pmt::string_to_symbol(acq_info_tag_name))
-            {
-                found_acq_info = true;
-                merged_acq_info.status |= decode_acq_info_tag(tag).status;
-            }
-            else
-            {
-                tag.offset = nitems_written(0) + i_out;
-                add_item_tag(0, tag);
-            }
-        }
-        if(found_acq_info)
-            add_item_tag(0, make_acq_info_tag(merged_acq_info, nitems_written(0) + i_out));
-
-        i_in += decim;
+      // add tags with corrected offset to the output stream
+      std::vector<gr::tag_t> tags;
+      get_tags_in_range(tags, 0, samp0_count, samp0_count + input_items.size());
+      for (const auto &tag : tags){
+          tag_t new_tag = tag;
+          if(decimation() != 0)
+              new_tag.offset = uint64_t(tag.offset / decimation());
+          else
+              new_tag.offset = uint64_t(tag.offset);
+          add_item_tag(0, new_tag);
       }
-
 
       return noutput_items;
     }

--- a/lib/freq_estimator_impl.cc
+++ b/lib/freq_estimator_impl.cc
@@ -91,16 +91,13 @@ namespace gr {
         }
       }
 
-      // add tags with fixed offset to the output stream
-      std::vector<gr::tag_t> trigger_tags;
-      get_tags_in_range(trigger_tags, 0, samp0_count, samp0_count + n_in);
-      for (const auto &trigger_tag : trigger_tags) {
-          tag_t new_tag = trigger_tag;
-          if(d_decim != 0)
-              new_tag.offset = uint64_t(trigger_tag.offset / d_decim);
-          else
-              new_tag.offset = uint64_t(trigger_tag.offset);
-          add_item_tag(0, new_tag);
+      // add tags with corrected offset to the output stream
+      std::vector<gr::tag_t> tags;
+      get_tags_in_range(tags, 0, samp0_count, samp0_count + n_in);
+      for (auto &tag : tags) {
+        if(d_decim != 0)
+          tag.offset = uint64_t(tag.offset / d_decim);
+        add_item_tag(0, tag);
       }
 
       consume_each(n_in);


### PR DESCRIPTION
Issue #33

Sorry, looks like what I did before in that method was much too complex. It is sufficient to just divide the `offset` by `decim` for each tag added to the output stream. (Tested on 4 picoscope system while counting incoming trigger tags and comparing them with the expected number)

The block is a "sync decimator", and therefor knows about it's decimation factor. So it theoretically should as well work to just use` tag_propagation_policy_t::TPP_ONE_TO_ONE`. Though I filed a bug against gnuradio regarding that, because using that seems to slowly eat memory in some consitions: https://github.com/gnuradio/gnuradio/issues/2364

 
