### PR TITLE
Log Error when Exception occurs during start/configure (Issue #95)

### DIFF
--- a/lib/digitizer_block_impl.cc
+++ b/lib/digitizer_block_impl.cc
@@ -702,8 +702,9 @@ namespace gr {
        d_configure_exception_message = ex.what();
        GR_LOG_ERROR(d_logger, d_configure_exception_message );
 
-       // It looks like the block is run by gnuradio, no matter if true or false is returned here
-       // TODO: "start" is called by gnuradio itself. Check if it is possible to stop the block from running when false is returned here.
+       // No matter if true or false is returned here, gnuradio will continue to run the block, so we stop in manually
+       // Re-throwing the exception would result in the binary getting stuck
+       this->stop();
        return false;
 
      } catch (...) {
@@ -711,8 +712,7 @@ namespace gr {
        d_configure_exception_message = "Unknown Exception received in digitizer_block_impl::start";
        GR_LOG_ERROR(d_logger, d_configure_exception_message );
 
-       // It looks like the block is run by gnuradio, no matter if true or false is returned here
-       // TODO: "start" is called by gnuradio itself. Check if it is possible to stop the block from running when false is returned here.
+       this->stop();
        return false;
      }
 

--- a/lib/digitizer_block_impl.cc
+++ b/lib/digitizer_block_impl.cc
@@ -700,9 +700,19 @@ namespace gr {
        }
      } catch (const std::exception& ex) {
        d_configure_exception_message = ex.what();
+       GR_LOG_ERROR(d_logger, d_configure_exception_message );
+
+       // It looks like the block is run by gnuradio, no matter if true or false is returned here
+       // TODO: "start" is called by gnuradio itself. Check if it is possible to stop the block from running when false is returned here.
        return false;
+
      } catch (...) {
+
        d_configure_exception_message = "Unknown Exception received in digitizer_block_impl::start";
+       GR_LOG_ERROR(d_logger, d_configure_exception_message );
+
+       // It looks like the block is run by gnuradio, no matter if true or false is returned here
+       // TODO: "start" is called by gnuradio itself. Check if it is possible to stop the block from running when false is returned here.
        return false;
      }
 


### PR DESCRIPTION
In order to Make Configuration errors at least more visible

I did not find out whats the consequence of returning "false" in `start`, seems to make no difference.

I suppose Fesa should check `d_configure_exception_message` and stop/abort the flowgraph when it is filled.

Fixes https://github.com/fair-acc/gr-digitizers/issues/95