### PR TITLE
Consistently use double for ranges (Issue #79)

### DIFF
--- a/lib/digitizer_block_impl.h
+++ b/lib/digitizer_block_impl.h
@@ -128,7 +128,7 @@ namespace gr {
           coupling(AC_1M)
       {}
 
-      float range;
+      double range;
       float offset;
       bool enabled;
       coupling_t coupling;

--- a/lib/picoscope_3000a_impl.cc
+++ b/lib/picoscope_3000a_impl.cc
@@ -82,7 +82,7 @@ namespace gr {
     }
 
     static PS3000A_RANGE
-    convert_to_ps3000a_range(float range)
+    convert_to_ps3000a_range(double range)
     {
       if (range == 0.01)
         return PS3000A_10MV;

--- a/lib/picoscope_4000a_impl.cc
+++ b/lib/picoscope_4000a_impl.cc
@@ -81,7 +81,7 @@ namespace gr {
     }
 
     static PS4000A_RANGE
-    convert_to_ps4000a_range(float range)
+    convert_to_ps4000a_range(double range)
     {
       if (range == 0.01)
         return PS4000A_10MV;

--- a/lib/picoscope_6000_impl.cc
+++ b/lib/picoscope_6000_impl.cc
@@ -69,7 +69,7 @@ namespace gr {
     *********************************************************************/
 
     static PS6000_COUPLING
-    convert_to_ps6000_coupling(coupling_t coupling, float desired_range)
+    convert_to_ps6000_coupling(coupling_t coupling, double desired_range)
     {
       if (desired_range >= 10.0 && coupling == DC_50R)
       {


### PR DESCRIPTION
Instead of mixing float/double, which leads to comparison failure

This fixes the problem described in https://github.com/fair-acc/gr-digitizers/issues/97  (comparison works fine now)

( Though I still would prefer the usage of enum values, to be more failsafe. This is just a "quickfix" to get stuff running. )

Currently at least two productive ps3000 devices suffer from this bug (whether the bug shows seems to dependent on the choosen channel ranges) 