### PR TITLE
Remove noisy warning

### DIFF
--- a/lib/digitizer_block_impl.cc
+++ b/lib/digitizer_block_impl.cc
@@ -973,8 +973,6 @@ namespace gr {
          std::chrono::duration<float> remaining_poll_duration = std::chrono::high_resolution_clock::now() - poll_start;
          if(remaining_poll_duration > poll_duration) {
            sleep_time = std::chrono::duration<float>::zero();
-           GR_LOG_WARN(d_logger, "Watchdog: Poll rate is set too low (" + std::to_string(d_poll_rate) + "s) "
-                                   "Cannot ensure that the Digitizer block work method will be called within that rate.");
          }
          else {
            sleep_time = poll_duration - remaining_poll_duration;

--- a/lib/digitizer_block_impl.cc
+++ b/lib/digitizer_block_impl.cc
@@ -970,12 +970,12 @@ namespace gr {
          }
 
          // Substract the time each iteration itself took in order to get closer to the desired poll duration
-         std::chrono::duration<float> remaining_poll_duration = std::chrono::high_resolution_clock::now() - poll_start;
-         if(remaining_poll_duration > poll_duration) {
+         std::chrono::duration<float> elapsed_poll_duration = std::chrono::high_resolution_clock::now() - poll_start;
+         if(elapsed_poll_duration > poll_duration) {
            sleep_time = std::chrono::duration<float>::zero();
          }
          else {
-           sleep_time = poll_duration - remaining_poll_duration;
+           sleep_time = poll_duration - elapsed_poll_duration;
          }
          std::this_thread::sleep_for(sleep_time);
        }


### PR DESCRIPTION
I was to quick with adding that warning in #92. The warning was printed alot on different servers, filling up our graylog with nonsense messages.

I tried to increase the poll duration to get rid of the warning. Though for some frontends, as soon as no warning was displayed, the number of received samples per time on the FESA side did not match the expectations any more (in some cases as well lost buffers were observed).

So I suppose it is normal / can be expected that ocasionally no waiting needs to be done, and it should not lead to a warning.