### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ which needs to be installed into the /opt/picoscope directory.
 
 Download and install PicoScope drivers from here: [https://www.picotech.com/downloads/linux](https://www.picotech.com/downloads/linux).
 
-In order to build the gr-digitizers module please follow the following steps:
-
 ```shell
 $ mkdir gr-digitizers/build
 $ cd gr-digitizers/build

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ which needs to be installed into the /opt/picoscope directory.
 
 Download and install PicoScope drivers from here: [https://www.picotech.com/downloads/linux](https://www.picotech.com/downloads/linux).
 
+Afterwards, you can build `gr-digitizers` like this:
+
 ```shell
 $ mkdir gr-digitizers/build
 $ cd gr-digitizers/build

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ $ cat ~/.gnuradio/config.conf
 local_blocks_path=/path/to/gr-digitizer/install/location/share/gnuradio/grc/blocks
 ```
 
-Check [this directory](examples) for wide range of examples.
+Check [this directory](examples) for a wide range of examples.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 
-# Building
+# gr-digitizers
+
+`gr-digitizers` is a collection of gnuradio blocks for signal processing.
+
+- It supports the usage of some [picotech](https://www.picotech.com/) soft oscilloscope devices as signal source.
+- In order to allign the data in time, gnuradio tags are used which are send together with the data.
+- Each data signal as well has a corresponding [rms](https://en.wikipedia.org/wiki/Root_mean_square)-error signal which is passed down the flowgraph together with the data.
+
+## Building and install
 
 In a nutshell we have three main dependencies:
  - [GNU Radio](https://www.gnuradio.org/) (boost, fftw, and some other libraries are required via dependency tree)
@@ -9,8 +17,6 @@ In a nutshell we have three main dependencies:
 GNU Radio and ROOT could be compiled/linked statically and required libraries could be in principle copied
 and deployed together with the test deploy unit. The only problem is PicoScope library (well libraries)
 which needs to be installed into the /opt/picoscope directory.
-
-# Building and install
 
 Download and install PicoScope drivers from here: [https://www.picotech.com/downloads/linux](https://www.picotech.com/downloads/linux).
 
@@ -37,7 +43,7 @@ $ lib/test-digitizers --enable-ps3000a-tests
 
 Note, HW related tests cannot be run in parallel.
 
-# Usage
+## Usage
 
 If you installed into a folder different from `/opt/gnuradio`, you will need to add the location of the new blocks into your `~/.gnuradio/config.conf`
 

--- a/README.md
+++ b/README.md
@@ -2,96 +2,31 @@
 # Building
 
 In a nutshell we have three main dependencies:
- - GNU Radio (boost, fftw, and some other libraries are required via dependency tree)
- - ROOT
- - PicoScope
+ - [GNU Radio](https://www.gnuradio.org/) (boost, fftw, and some other libraries are required via dependency tree)
+ - [ROOT](https://root.cern/)
+ - [PicoScope Drivers](https://www.picotech.com/downloads/linux).
 
 GNU Radio and ROOT could be compiled/linked statically and required libraries could be in principle copied
 and deployed together with the test deploy unit. The only problem is PicoScope library (well libraries)
 which needs to be installed into the /opt/picoscope directory.
 
-
-## Building gnuradio from source (static build, dynamic boost)
-
-See [https://wiki.gnuradio.org/index.php/BuildGuide](https://wiki.gnuradio.org/index.php/BuildGuide).
-
-Note, install location should be '/opt/gnuradio', and it should be statically build. This assumption
-is made by FESA level code.
-
-Steps:
-
-git clone --recursive https://github.com/gnuradio/gnuradio.git
-
-
-Comment out the following lines in `<top>/volk/apps/CMakeLists.txt`:
-
-```shell
-  set_target_properties(volk_profile PROPERTIES LINK_FLAGS "-static")
-  set_target_properties(volk-config-info PROPERTIES LINK_FLAGS "-static")
-```
-
-```shell
-cmake .. -DCMAKE_INSTALL_PREFIX=/opt/gnuradio \
-	-DENABLE_GR_ANALOG=ON \
-	-DENABLE_STATIC_LIBS=ON
-```
-
-Dependencies:
-
-sudo yum install fftw-devel
-
-
-# Building gr-digitizers module
+# Building and install
 
 Download and install PicoScope drivers from here: [https://www.picotech.com/downloads/linux](https://www.picotech.com/downloads/linux).
 
 In order to build the gr-digitizers module please follow the following steps:
 
 ```shell
-$ cd gr-digitizers
-$ mkdir build
-$ cd build
-$ cmake .. -DCMAKE_PREFIX_PATH=/opt/gnuradio \
-           -DCMAKE_INSTALL_PREFIX=/opt/gnuradio \
-           -DENABLE_GR_LOG=1 \
-           -DENABLE_STATIC_LIBS=ON \
-           -DCMAKE_BUILD_TYPE=Debug
+$ mkdir gr-digitizers/build
+$ cd gr-digitizers/build
+$ cmake .. -DENABLE_GR_LOG=1 \
+           -DENABLE_STATIC_LIBS=ONN
+$ make
+$ ./lib/test_digitizers_test.sh # runs unit tests
+$ make install
 ```
-Note the cmake variables used above can be omitted if the standard GNU Radio installation is used. In the
-example above it is assumed that the GNU Radio is istalled in the `/opt/gnuradio` directory.
-
-To install the module execute the following command:
-
-```shell
-$ sudo make install
-```
-Note, depending on the system configuration the following two configuration files might be required:
-
-```shell
-$ cat ~/.gnuradio/config.conf 
-[grc]
-local_blocks_path=/opt/gnuradio/share/gnuradio/grc/blocks
-
-$ cat /etc/ld.so.conf.d/gnuradio.conf 
-/opt/gnuradio/lib64
-
-$ cat ~/.bashrc 
-
-<some output ommited>
-
-PYTHONPATH=$PYTHONPATH:/usr/local/lib64/python2.7/site-packages/
-export PYTHONPATH
-
-```
-When changing the loader configuration, don't forget to run `sudo ldconfig` command afterwards.
-
-# Run unit tests
-
-From the build directory execute the following command to run the unit tests:
-
-```shell
-$ ctest
-```
+- For debug output add the following to cmake: `-DDEBUG_ENABLED=1`
+- Configure the install location with `-DCMAKE_INSTALL_PREFIX=/path/to/gr-digitizer/install/location` 
 
 By default only unit tests wihtout any HW dependencies are executed. In order to execute PicoScope 3000a
 related tests execute the below command (from you build directory):
@@ -102,38 +37,14 @@ $ lib/test-digitizers --enable-ps3000a-tests
 
 Note, HW related tests cannot be run in parallel.
 
-# Examples
+# Usage
 
-See gr-digitizers/examples/grc directory.
-
-
-# Dependencies
-
-## ROOT Framework
+If you installed into a folder different from `/opt/gnuradio`, you will need to add the location of the new blocks into your `~/.gnuradio/config.conf`
 
 ```shell
-$ sudo yum install root-*
-```
-On CentOS 7 (cmake version 2.8.12), the CMake find_package command does not set needed ROOT components correctly,
-namely MathCore and Graf, but rather pulls in all the libraries. In order to overcome this, uncomment the following 
-two lines in the `gr-digitizers/lib/CMakeLists.txt` file:
-
-```
-    #/usr/lib64/root/libMathCore.so
-    #/usr/lib64/root/libGraf.so
-```
-And comment out the following line:
-
-```
-    ${ROOT_LIBRARIES}
+$ cat ~/.gnuradio/config.conf 
+[grc]
+local_blocks_path=/path/to/gr-digitizer/install/location/share/gnuradio/grc/blocks
 ```
 
-## Picoscope Drivers
-
-Available from here: [https://www.picotech.com/downloads/linux](https://www.picotech.com/downloads/linux).
-
-# Known Bugs
-
-1) In rapid block mode acquisition is automatically started if no trigger is received for more than ~1 hour. This seems
-   to be HW (or driver) related bug (relavant for 3000 series devices only).
-
+Check [this directory](examples) for wide range of examples.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Afterwards, you can build `gr-digitizers` like this:
 $ mkdir gr-digitizers/build
 $ cd gr-digitizers/build
 $ cmake .. -DENABLE_GR_LOG=1 \
-           -DENABLE_STATIC_LIBS=ONN
+           -DENABLE_STATIC_LIBS=ON
 $ make
 $ ./lib/test_digitizers_test.sh # runs unit tests
 $ make install


### PR DESCRIPTION
Update and simplify README.md

- No build details for the dependencies in the gr-digitizer README
- Not required to build gnuradio from source
- Simplied structure, remove obsolete stuff

Intension: Cleanup before moving stuff from https://git.gsi.de/acc/specs/generic-daq/-/blob/main/README.md into this README

Result looks like this: https://github.com/fair-acc/gr-digitizers/blob/alexxcons-README/README.md