### PR TITLE
CI: update sonar-scanner action to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install sonar-scanner and build-wrapper
         if: matrix.configurations.compiler == 'gcc13' && matrix.cmake-build-type == 'Debug'
-        uses: SonarSource/sonarcloud-github-c-cpp@v1
+        uses: SonarSource/sonarcloud-github-c-cpp@v2
 
       - name: Install picoscope libraries
         run: |


### PR DESCRIPTION
v1 of the action uses java11 which will not be supported after end of this month.