### PR TITLE
test-timing: more debug output for sdl+gl3 init and bump imgui

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ else ()
     FetchContent_Declare(
             imgui
             GIT_REPOSITORY  https://github.com/ocornut/imgui.git
-            GIT_TAG         v1.90
+            GIT_TAG         v1.90.1
     )
 
     # Enables 32 bit vertex indices for ImGui

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(ENABLE_TESTING OFF)
 FetchContent_Declare(
     graph-prototype
     GIT_REPOSITORY https://github.com/fair-acc/graph-prototype.git
-    GIT_TAG 9f24bac891cef9e667a0f5719c666765e2a922d5 # main as of 2023-11-09
+    GIT_TAG 953501708db91ecda21805b6e2dd8af1da50399c # main as of 2024-01-02
 )
 
 FetchContent_Declare(


### PR DESCRIPTION
ImGUI had a regression in the dynamic loader for libGL. This commit improves diagnostic logging and bumps imgui to a version containing the fix.
See https://github.com/ocornut/imgui/commit/a3eea8a75a073694df72a31530632804df0001ec