### PR TITLE
Fix qa_Picoscope4000a regressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(ENABLE_TESTING OFF)
 FetchContent_Declare(
     graph-prototype
     GIT_REPOSITORY https://github.com/fair-acc/graph-prototype.git
-    GIT_TAG 953501708db91ecda21805b6e2dd8af1da50399c # main as of 2024-01-02
+    GIT_TAG 7d22e962c7f67fee95fd98c38bdb32ccde78d616 # main as of 2024-01-17
 )
 
 FetchContent_Declare(

--- a/blocklib/helpers/HelperBlocks.hpp
+++ b/blocklib/helpers/HelperBlocks.hpp
@@ -46,26 +46,6 @@ struct VectorSink : public gr::Block<VectorSink<T>> {
 };
 
 template<typename T>
-struct TagDebug : public gr::Block<TagDebug<T>> {
-    gr::PortIn<T>        in;
-    gr::PortOut<T>       out;
-    std::vector<gr::Tag> seen_tags;
-    std::size_t          samples_seen = 0;
-
-    gr::work::Status
-    processBulk(std::span<const T> input, std::span<T> output) noexcept {
-        std::copy(input.begin(), input.end(), output.begin());
-        if (this->input_tags_present()) {
-            auto tag = this->input_tags()[0];
-            tag.index += static_cast<int64_t>(samples_seen);
-            seen_tags.push_back(std::move(tag));
-        }
-        samples_seen += input.size();
-        return gr::work::Status::OK;
-    }
-};
-
-template<typename T>
 struct CountSink : public gr::Block<CountSink<T>> {
     gr::PortIn<T> in;
     std::size_t   samples_seen = 0;
@@ -81,7 +61,6 @@ struct CountSink : public gr::Block<CountSink<T>> {
 
 ENABLE_REFLECTION_FOR_TEMPLATE(fair::helpers::VectorSource, out, data);
 ENABLE_REFLECTION_FOR_TEMPLATE(fair::helpers::VectorSink, in, data);
-ENABLE_REFLECTION_FOR_TEMPLATE(fair::helpers::TagDebug, in, out);
 ENABLE_REFLECTION_FOR_TEMPLATE(fair::helpers::CountSink, in);
 
 #endif

--- a/blocklib/picoscope/test/CMakeLists.txt
+++ b/blocklib/picoscope/test/CMakeLists.txt
@@ -4,7 +4,7 @@ function(add_ut_test_tool TEST_NAME)
     target_compile_options(${TEST_NAME} PRIVATE -Wall)
     target_link_options(${TEST_NAME} PRIVATE -Wall)
     target_include_directories(${TEST_NAME} PRIVATE ${CMAKE_BINARY_DIR}/include ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-    target_link_libraries(${TEST_NAME} PRIVATE gnuradio-core fair-picoscope fair-helpers ut)
+    target_link_libraries(${TEST_NAME} PRIVATE gnuradio-core gr-testing fair-picoscope fair-helpers ut)
 endfunction()
 
 add_ut_test_tool(qa_Picoscope4000a)


### PR DESCRIPTION
Bump to latest graph-prototype and fix the regressions with Picoscope4000a by adapting to the new lifecycle API.
