### PR TITLE
bump to latest GR4.0-alpha

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,14 @@ if (NOT DEFINED GR_DIGITIZERS_TOPLEVEL_PROJECT)
     endif ()
 endif ()
 
+if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang") # set default C++ STL to Clang's libc++ when using Clang
+    add_compile_options(-stdlib=libc++ -fcolor-diagnostics)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++")
+    set(CLANG true)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    add_compile_options(-fdiagnostics-color=always)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
 
 include(cmake/CMakeRC.cmake)
@@ -21,7 +29,7 @@ set(ENABLE_TESTING OFF)
 FetchContent_Declare(
     graph-prototype
     GIT_REPOSITORY https://github.com/fair-acc/graph-prototype.git
-    GIT_TAG c9b2dd33dcfaf7ab56dc6b1c42b73f46e7dfc001 # main as of 2024-02-01
+    GIT_TAG ed9738d809d4f89ddbbee49fd9a3bbd87c27bfab # main as of 2024-02-20
 )
 
 FetchContent_Declare(

--- a/blocklib/timing/CMakeLists.txt
+++ b/blocklib/timing/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (NOT EMSCRIPTEN)
+if (NOT EMSCRIPTEN AND NOT CLANG)
     add_library(timing INTERFACE)
     target_include_directories(timing INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include/)
 

--- a/blocklib/timing/include/timing.hpp
+++ b/blocklib/timing/include/timing.hpp
@@ -124,14 +124,14 @@ public:
             static_assert(position + bitsize <= 64); // assert that we only consider existing bits
             static_assert(std::numeric_limits<ReturnType>::max() >= ((1UL << bitsize) - 1)); // make sure the data fits into the return type
             return static_cast<ReturnType>((value >> position) & ((1UL <<  bitsize) - 1));
-        };
+        }
 
         template <std::size_t position, std::size_t bitsize, typename FieldType>
         static constexpr uint64_t fromField(FieldType value) {
             static_assert(position + bitsize <= 64);
             static_assert(std::numeric_limits<FieldType>::max() >= ((1UL << bitsize) - 1));
             return ((value & ((1UL <<  bitsize) - 1)) <<  position);
-        };
+        }
 
         explicit Event(uint64_t timestamp = 0, uint64_t id = 1UL << 60, uint64_t param= 0, uint16_t _flags = 0, uint64_t _executed = 0) :
             // id

--- a/blocklib/timing/test/CMakeLists.txt
+++ b/blocklib/timing/test/CMakeLists.txt
@@ -12,6 +12,7 @@ function(add_ut_test TEST_NAME)
     add_test(NAME ${TEST_NAME} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME})
 endfunction()
 
-add_ut_test(qa_timing)
-target_link_libraries(qa_timing PRIVATE timing PkgConfig::saftlib PkgConfig::etherbone)
-
+if(NOT EMSCRIPTEN AND NOT CLANG) ## clang/libc++ does not support the require <chrono> features to convert from TAI to UTC and 'std::views::enumerate'
+    add_ut_test(qa_timing)
+    target_link_libraries(qa_timing PRIVATE timing PkgConfig::saftlib PkgConfig::etherbone)
+endif()


### PR DESCRIPTION
minor fixes:
 * `CircularBuffer::reserve_output_range(nSamples)` -> `CircularBuffer::reserve(nSamples)`
 * changed/removed manual block state handling in Picoscope
 * removed superfluous ';'
 
 **EDIT:**
 clang/libc++ does not support the required `<chrono>` features to convert from TAI to UTC and `std::views::enumerate`. I looked into basic workarounds but this became rather ugly. Since this should be solved by itself rather soon (both things are being actively worked upon within clang/libc++),  I thus disabled the timing-related blocks and unit-tests for the time being for Emscripten and Clang.