### PR TITLE
Frank/fix metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ set(ENABLE_TESTING OFF)
 FetchContent_Declare(
     graph-prototype
     GIT_REPOSITORY https://github.com/fair-acc/graph-prototype.git
-    GIT_TAG 7f22e217e88ef54fe45ece84f804f6de8b7ff989 # main as of 2024-02-22
+    GIT_TAG 1f3469c73ea182b38ff66f18d46e5251fc1edbf8 # main as of 2024-03-07
 )
 
 FetchContent_Declare(

--- a/blocklib/picoscope/Picoscope.hpp
+++ b/blocklib/picoscope/Picoscope.hpp
@@ -97,10 +97,10 @@ struct Channel {
     gr::property_map
     signalInfo() const {
         using namespace gr;
-        static const auto kSignalName = std::string(tag::SIGNAL_NAME.key());
-        static const auto kSignalUnit = std::string(tag::SIGNAL_UNIT.key());
-        static const auto kSignalMin  = std::string(tag::SIGNAL_MIN.key());
-        static const auto kSignalMax  = std::string(tag::SIGNAL_MAX.key());
+        static const auto kSignalName = std::string(tag::SIGNAL_NAME.shortKey());
+        static const auto kSignalUnit = std::string(tag::SIGNAL_UNIT.shortKey());
+        static const auto kSignalMin  = std::string(tag::SIGNAL_MIN.shortKey());
+        static const auto kSignalMax  = std::string(tag::SIGNAL_MAX.shortKey());
         return {
             { kSignalName, settings.name }, { kSignalUnit, settings.unit }, { kSignalMin, static_cast<float>(settings.offset) }, { kSignalMax, static_cast<float>(settings.offset + settings.range) }
         };
@@ -547,7 +547,7 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
                 // raw index is index - 1
                 writeTags[0].index            = static_cast<int64_t>(ps_state.produced_worker - 1);
                 writeTags[0].map              = channel.signalInfo();
-                static const auto kSampleRate = std::string(gr::tag::SAMPLE_RATE.key());
+                static const auto kSampleRate = std::string(gr::tag::SAMPLE_RATE.shortKey());
                 writeTags[0].map[kSampleRate] = static_cast<float>(sample_rate);
                 channel.signal_info_written   = true;
             }

--- a/blocklib/timing/src/test-timing.cpp
+++ b/blocklib/timing/src/test-timing.cpp
@@ -256,7 +256,7 @@ void showTimingEventTable(Timing &timing) {
             ImGui::TableSetupColumn("##addToSchedule");
 
             ImGui::TableHeadersRow();
-            auto data = event_reader.get();
+            auto data = event_reader.get(event_reader.available());
 
             for (const auto &evt : std::ranges::reverse_view{data}) {
                 drawSnoopedEventTableRow(evt, timing);
@@ -636,7 +636,7 @@ public:
     explicit TimePlot(BufferT &_events) : snoopReader{_events.new_reader()} { }
 
     void updateStreaming() {
-        auto newEvents = snoopReader.get();
+        auto newEvents = snoopReader.get(snoopReader.available());
         if (startTime == 0 && !newEvents.empty()) {
             startTime = newEvents[0].time;
         }

--- a/blocklib/timing/test/qa_timing.cpp
+++ b/blocklib/timing/test/qa_timing.cpp
@@ -18,7 +18,7 @@ const boost::ut::suite TimingTests = [] {
         timing.injectEvent(Timing::Event{5000, 0x1234, 0x12}, timing.currentTimeTAI());
         std::this_thread::sleep_for(20ms);
         timing.process();
-        auto data = reader.get();
+        auto data = reader.get(reader.available());
         expect(data.size() == 2_ul);
         expect(data[0].id() == 0x10);
         expect(data[1].param() == 0x12);
@@ -32,7 +32,7 @@ const boost::ut::suite TimingTests = [] {
         timing.injectEvent(Timing::Event{2000, 0x10, 0x20}, timing.currentTimeTAI());
         timing.injectEvent(Timing::Event{5000, 0x1234, 0x12}, timing.currentTimeTAI());
         timing.process();
-        auto data = reader.get();
+        auto data = reader.get(reader.available());
         expect(data.size() == 2_ul);
         expect(data[0].id() == 0x10);
         expect(data[1].param() == 0x12);


### PR DESCRIPTION
Fixes metadata propagation from Picoscope.

Also update graph-prototype to latest main.