### PR TITLE
Refactor Picoscope implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ set(ENABLE_TESTING OFF)
 FetchContent_Declare(
     graph-prototype
     GIT_REPOSITORY https://github.com/fair-acc/graph-prototype.git
-    GIT_TAG 406923204a53ee72ad66f2a21e776da361820fe9 # main as of 2024-05-23
+    GIT_TAG 5d88ea699408d6b6546b6f9fe7f0f0abd616f854 # main as of 2024-06-12
 )
 
 FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ set(ENABLE_TESTING OFF)
 FetchContent_Declare(
     graph-prototype
     GIT_REPOSITORY https://github.com/fair-acc/graph-prototype.git
-    GIT_TAG 5e15e8478d267a5e74fdd3b310a7483a690fe1b4 # main as of 2024-04-25
+    GIT_TAG 406923204a53ee72ad66f2a21e776da361820fe9 # main as of 2024-05-23
 )
 
 FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ set(ENABLE_TESTING OFF)
 FetchContent_Declare(
     graph-prototype
     GIT_REPOSITORY https://github.com/fair-acc/graph-prototype.git
-    GIT_TAG 5d88ea699408d6b6546b6f9fe7f0f0abd616f854 # main as of 2024-06-12
+    GIT_TAG 4b05d3059335d14e9fa2eb44b43bb37a4881409c # main as of 2024-06-18
 )
 
 FetchContent_Declare(

--- a/blocklib/helpers/HelperBlocks.hpp
+++ b/blocklib/helpers/HelperBlocks.hpp
@@ -45,22 +45,9 @@ struct VectorSink : public gr::Block<VectorSink<T>> {
     }
 };
 
-template<typename T>
-struct CountSink : public gr::Block<CountSink<T>> {
-    gr::PortIn<T> in;
-    std::size_t   samples_seen = 0;
-
-    gr::work::Status
-    processBulk(std::span<const T> input) noexcept {
-        samples_seen += input.size();
-        return gr::work::Status::OK;
-    }
-};
-
 } // namespace fair::helpers
 
 ENABLE_REFLECTION_FOR_TEMPLATE(fair::helpers::VectorSource, out, data);
 ENABLE_REFLECTION_FOR_TEMPLATE(fair::helpers::VectorSink, in, data);
-ENABLE_REFLECTION_FOR_TEMPLATE(fair::helpers::CountSink, in);
 
 #endif

--- a/blocklib/picoscope/CMakeLists.txt
+++ b/blocklib/picoscope/CMakeLists.txt
@@ -5,10 +5,16 @@ set_property(TARGET ps4000a PROPERTY
 target_link_libraries(ps4000a INTERFACE PkgConfig::zlib PkgConfig::libusb)
 target_include_directories(ps4000a INTERFACE ${PICOSCOPE_PREFIX}/include/libps4000a ${PICOSCOPE_PREFIX}/include/libps5000a) # Hack: PicoCallback.h is missing in libps4000a/
 
+add_library(ps5000a SHARED IMPORTED GLOBAL)
+set_property(TARGET ps5000a PROPERTY
+             IMPORTED_LOCATION ${PICOSCOPE_PREFIX}/lib/libps5000a.so)
+target_link_libraries(ps5000a INTERFACE PkgConfig::zlib PkgConfig::libusb)
+target_include_directories(ps5000a INTERFACE ${PICOSCOPE_PREFIX}/include/libps5000a)
+
 add_library(fair-picoscope INTERFACE)
 target_include_directories(fair-picoscope INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/>)
 
-target_link_libraries(fair-picoscope INTERFACE ps4000a gr-digitizers-options gnuradio-core refl-cpp fmt)
+target_link_libraries(fair-picoscope INTERFACE ps4000a ps5000a gr-digitizers-options gnuradio-core refl-cpp fmt)
 set_target_properties(gr-digitizers PROPERTIES PUBLIC_HEADER "Picoscope.hpp;Picoscope4000a.hpp;StatusMessages.hpp")
 
 if (ENABLE_GR_DIGITIZERS_TESTING)

--- a/blocklib/picoscope/Picoscope.hpp
+++ b/blocklib/picoscope/Picoscope.hpp
@@ -228,7 +228,7 @@ using gr::Visible;
  *
  * - gr::UncertainValue<float>
  *   Same as "float", except it also contains the estimated measurement error as an additional component.
-**/
+ **/
 template<typename T>
 concept PicoscopeOutput = std::disjunction_v<std::is_same<T, std::int16_t>, std::is_same<T, float>, std::is_same<T, gr::UncertainValue<float>>>;
 
@@ -247,10 +247,12 @@ struct PicoscopeBlockingHelper<TPSImpl, true> {
 };
 
 template<PicoscopeOutput T, AcquisitionMode acquisitionMode, typename TPSImpl>
-
 class Picoscope : public PicoscopeBlockingHelper<TPSImpl, acquisitionMode == AcquisitionMode::RapidBlock>::type {
 public:
-    using PicoscopeBlockingHelper<TPSImpl, acquisitionMode == AcquisitionMode::RapidBlock>::type::Block;
+    using super_t = typename PicoscopeBlockingHelper<TPSImpl, acquisitionMode == AcquisitionMode::RapidBlock>::type;
+
+    Picoscope(gr::property_map props) : super_t(std::move(props)) {}
+
     A<std::string, "serial number">   serial_number;
     A<double, "sample rate", Visible> sample_rate = 10000.;
     // TODO any way to get custom enums into pmtv??
@@ -276,9 +278,9 @@ public:
     detail::Settings                                                  ps_settings;
 
 private:
-    std::mutex                                                        g_init_mutex;
-    std::size_t                                                       streamingSamples = 0Z;
-    std::queue<gr::property_map>                                      timingMessages;
+    std::mutex                   g_init_mutex;
+    std::size_t                  streamingSamples = 0Z;
+    std::queue<gr::property_map> timingMessages;
 
 public:
     ~Picoscope() { stop(); }

--- a/blocklib/picoscope/Picoscope.hpp
+++ b/blocklib/picoscope/Picoscope.hpp
@@ -4,12 +4,12 @@
 #include "StatusMessages.hpp"
 
 #include <gnuradio-4.0/Block.hpp>
+#include <PicoConnectProbes.h>
 
 #include <fmt/format.h>
 
 #include <functional>
-
-// #define GR_PICOSCOPE_POLLER_THREAD 1
+#include <queue>
 
 namespace fair::picoscope {
 
@@ -232,8 +232,22 @@ using gr::Visible;
 template<typename T>
 concept PicoscopeOutput = std::disjunction_v<std::is_same<T, std::int16_t>, std::is_same<T, float>, std::is_same<T, gr::UncertainValue<float>>>;
 
-template<PicoscopeOutput T, typename TPSImpl>
-struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::SupportedTypes<int16_t, float, double>> {
+// helper struct to conditionally enable BlockingIO at compile time
+template<typename TPSImpl, bool>
+struct PicoscopeBlockingHelper;
+
+template<typename TPSImpl>
+struct PicoscopeBlockingHelper<TPSImpl, false> {
+    using type = gr::Block<TPSImpl, gr::SupportedTypes<int16_t, float, double>>;
+};
+
+template<typename TPSImpl>
+struct PicoscopeBlockingHelper<TPSImpl, true> {
+    using type = gr::Block<TPSImpl, gr::SupportedTypes<int16_t, float, double>, gr::BlockingIO<false>>;
+};
+
+template<PicoscopeOutput T, AcquisitionMode acquisitionMode, typename TPSImpl>
+struct Picoscope : public PicoscopeBlockingHelper<TPSImpl, acquisitionMode == AcquisitionMode::RapidBlock>::type {
     A<std::string, "serial number">   serial_number;
     A<double, "sample rate", Visible> sample_rate = 10000.;
     // TODO any way to get custom enums into pmtv??
@@ -257,6 +271,10 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
 
     detail::State<T>                                                  ps_state;
     detail::Settings                                                  ps_settings;
+
+    std::mutex                                                        g_init_mutex;
+    std::size_t                                                       streamingSamples;
+    std::queue<gr::property_map>                                      timingMessages;
 
     ~Picoscope() { stop(); }
 
@@ -301,39 +319,6 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
         }
     }
 
-    gr::work::Result
-    workImpl() noexcept {
-        using enum gr::work::Status;
-
-        if (ps_state.channels.empty()) {
-            return { 0, 0, ERROR };
-        }
-
-        if (const auto errors_available = ps_state.errors.reader.available(); errors_available > 0) {
-            auto errors = ps_state.errors.reader.get(errors_available);
-            std::ignore = errors.consume(errors.size());
-            return { 0, 0, ERROR };
-        }
-
-        if (ps_state.data_finished) {
-            this->requestStop();
-            this->publishTag({ { gr::tag::END_OF_STREAM, true } }, 0);
-            return { 0, 0, DONE };
-        }
-
-#ifndef GR_PICOSCOPE_POLLER_THREAD
-        if (ps_settings.acquisition_mode == AcquisitionMode::Streaming) {
-            if (const auto ec = self().driver_poll()) {
-                // TODO tolerate or return ERROR
-                reportError(ec);
-                fmt::println(std::cerr, "poll failed");
-            }
-        }
-#endif
-
-        return { 0, 0, OK };
-    }
-
     // TODO only for debugging, maybe remove
     std::size_t
     producedWorker() const {
@@ -352,7 +337,7 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
             if (ps_settings.auto_arm) {
                 arm();
             }
-            if (ps_settings.acquisition_mode == AcquisitionMode::Streaming) {
+            if (acquisitionMode == AcquisitionMode::Streaming) {
                 startPollThread();
             }
             ps_state.started = true;
@@ -376,7 +361,7 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
         disarm();
         close();
 
-        if (ps_settings.acquisition_mode == AcquisitionMode::Streaming) {
+        if (acquisitionMode == AcquisitionMode::Streaming) {
             stopPollThread();
         }
     }
@@ -390,30 +375,6 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
         if (ps_state.poller_state == detail::PollerState::Exit) {
             ps_state.poller_state = detail::PollerState::Idle;
         }
-#ifdef GR_PICOSCOPE_POLLER_THREAD
-        const auto pollDuration = std::chrono::seconds(1) * ps_settings.streaming_mode_poll_rate;
-
-        state.poller            = std::thread([this, pollDuration] {
-            while (state.poller_state != detail::poller_state_t::Exit) {
-                if (state.poller_state == detail::poller_state_t::Idle) {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-                    continue;
-                }
-
-                const auto pollStart = std::chrono::high_resolution_clock::now();
-
-                if (const auto ec = self().driver_poll()) {
-                    fmt::println(std::cerr, "poll failed: {}", ec.message());
-                }
-                // Substract the time each iteration itself took in order to get closer to
-                // the desired poll duration
-                const auto elapsedPollDuration = std::chrono::high_resolution_clock::now() - pollStart;
-                if (elapsedPollDurationuration < pollDuration) {
-                    std::this_thread::sleep_for(pollDuration - elapsedPollDuration);
-                }
-            }
-        });
-#endif
     }
 
     void
@@ -483,7 +444,7 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
         }
 
         ps_state.armed = true;
-        if (ps_settings.acquisition_mode == AcquisitionMode::Streaming) {
+        if (acquisitionMode == AcquisitionMode::Streaming) {
             ps_state.poller_state = detail::PollerState::Running;
         }
     }
@@ -494,7 +455,7 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
             return;
         }
 
-        if (ps_settings.acquisition_mode == AcquisitionMode::Streaming) {
+        if (acquisitionMode == AcquisitionMode::Streaming) {
             ps_state.poller_state = detail::PollerState::Idle;
         }
 
@@ -506,7 +467,7 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
     }
 
     void
-    processDriverData(std::size_t nrSamples, std::size_t offset) {
+    processDriverData(std::size_t nrSamples, std::size_t offset, auto &outputs) {
         std::vector<std::size_t> triggerOffsets;
 
         using ChannelOutputRange = decltype(ps_state.channels[0].data_writer.reserve(1));
@@ -516,8 +477,9 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
         for (std::size_t channelIdx = 0; channelIdx < ps_state.channels.size(); ++channelIdx) {
             auto &channel = ps_state.channels[channelIdx];
 
-            channelOutputs.push_back(channel.data_writer.reserve(nrSamples));
-            auto      &output     = channelOutputs[channelIdx];
+            // channelOutputs.push_back(channel.data_writer.reserve(nrSamples));
+            // auto      &output     = channelOutputs[channelIdx];
+            auto      &output     = outputs[channelIdx];
 
             const auto driverData = std::span(channel.driver_buffer).subspan(offset, nrSamples);
 
@@ -530,7 +492,7 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
                     if constexpr (std::is_same_v<T, float>) {
                         output[i] = voltageMultiplier * driverData[i];
                     } else if constexpr (std::is_same_v<T, gr::UncertainValue<float>>) {
-                        output[i] = gr::UncertainValue(voltageMultiplier * driverData[i]);
+                        output[i] = gr::UncertainValue(voltageMultiplier * driverData[i], self().uncertainty());
                     }
                 }
             }
@@ -543,16 +505,23 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
         const auto now = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now().time_since_epoch());
 
         // TODO wait (block) here for timing messages if trigger count > timing message count
-        // TODO pair up trigger offsets with timing messages
 
         std::vector<gr::Tag> triggerTags;
         triggerTags.reserve(triggerOffsets.size());
 
         for (const auto triggerOffset : triggerOffsets) {
+            gr::property_map timing;
+            if (timingMessages.empty()) {
+                // fallback to ad-hoc timing message
+                timing = gr::property_map{ { gr::tag::TRIGGER_NAME, "PPS" }, { gr::tag::TRIGGER_TIME, static_cast<uint64_t>(now.count()) } };
+            } else {
+                // use timing message that we received over the message port if any
+                timing = timingMessages.front();
+                timingMessages.pop();
+            }
+
             // raw index is index - 1
-            triggerTags.emplace_back(static_cast<int64_t>(ps_state.produced_worker + triggerOffset - 1), gr::property_map{ // TODO use data from timing message
-                                                                                                                           { gr::tag::TRIGGER_NAME, "PPS" },
-                                                                                                                           { gr::tag::TRIGGER_TIME, static_cast<uint64_t>(now.count()) } });
+            triggerTags.emplace_back(static_cast<int64_t>(ps_state.produced_worker + triggerOffset - 1), timing);
         }
 
         for (auto &channel : ps_state.channels) {
@@ -567,7 +536,7 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
                 writeTags[0].index            = static_cast<int64_t>(ps_state.produced_worker - 1);
                 writeTags[0].map              = channel.signalInfo();
                 static const auto kSampleRate = std::string(gr::tag::SAMPLE_RATE.shortKey());
-                writeTags[0].map[kSampleRate] = static_cast<float>(sample_rate);
+                writeTags[0].map[kSampleRate] = pmtv::pmt(static_cast<float>(sample_rate));
                 channel.signal_info_written   = true;
             }
             std::copy(triggerTags.begin(), triggerTags.end(), writeTags.begin() + (writeSignalInfo ? 1 : 0));
@@ -575,7 +544,7 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
         }
 
         // once all tags have been written, publish the data
-        for (auto &output : channelOutputs) {
+        for (auto &output : outputs) {
             output.publish(nrSamples);
         }
 
@@ -583,7 +552,10 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
     }
 
     void
-    streamingCallback(int32_t nrSamplesSigned, uint32_t startIndex, int16_t overflow) {
+    streamingCallback(int32_t nrSamplesSigned, uint32_t startIndex, int16_t overflow)
+        requires(acquisitionMode == AcquisitionMode::Streaming)
+    {
+        streamingSamples = static_cast<std::size_t>(nrSamplesSigned);
         assert(nrSamplesSigned >= 0);
         const auto nrSamples = static_cast<std::size_t>(nrSamplesSigned);
 
@@ -596,30 +568,74 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
         if (nrSamples == 0) {
             return;
         }
-
-        processDriverData(nrSamples, startIndex);
     }
 
     void
-    rapidBlockCallback(Error ec) {
+    rapidBlockCallback(Error ec)
+        requires(acquisitionMode == AcquisitionMode::RapidBlock)
+    {
         if (ec) {
             reportError(ec);
             return;
         }
-        const auto samples = ps_settings.pre_samples + ps_settings.post_samples;
-        for (std::size_t capture = 0; capture < ps_settings.rapid_block_nr_captures; ++capture) {
-            const auto getValuesResult = self().driver_rapidBlockGetValues(capture, samples);
-            if (getValuesResult.error) {
-                reportError(ec);
-                return;
-            }
+        this->invokeWork();
+    }
 
-            // TODO handle overflow for individual channels?
-            processDriverData(getValuesResult.samples, 0);
+    gr::work::Status
+    processBulk(auto &output) {
+        if constexpr (acquisitionMode == AcquisitionMode::Streaming) {
+            if (const auto ec = self().driver_poll()) {
+                reportError(ec);
+                fmt::println(std::cerr, "poll failed");
+                return gr::work::Status::ERROR;
+            }
+            processDriverData(streamingSamples, 0, output);
+            streamingSamples = 0;
+        } else {
+            const auto samples = ps_settings.pre_samples + ps_settings.post_samples;
+            for (std::size_t capture = 0; capture < ps_settings.rapid_block_nr_captures; ++capture) {
+                const auto getValuesResult = self().driver_rapidBlockGetValues(capture, samples);
+                if (getValuesResult.error) {
+                    reportError(getValuesResult.error);
+                    return gr::work::Status::ERROR;
+                }
+
+                // TODO handle overflow for individual channels?
+                processDriverData(getValuesResult.samples, 0, output);
+            }
         }
 
         if (ps_settings.trigger_once) {
             ps_state.data_finished = true;
+        }
+
+        if (ps_state.channels.empty()) {
+            return gr::work::Status::OK;
+        }
+
+        if (const auto errors_available = ps_state.errors.reader.available(); errors_available > 0) {
+            auto errors = ps_state.errors.reader.get(errors_available);
+            std::ignore = errors.consume(errors.size());
+            return gr::work::Status::ERROR;
+        }
+
+        if (ps_state.data_finished) {
+            this->requestStop();
+            this->publishTag({ { gr::tag::END_OF_STREAM, true } }, 0);
+
+            return gr::work::Status::DONE;
+        }
+
+        return gr::work::Status::OK;
+    }
+
+    void
+    processMessages(gr::MsgPortInNamed<"__Builtin"> &, std::span<const gr::Message> messages) {
+        for (auto &msg : messages) {
+            if (msg.data.has_value()) {
+                // store timing messages for later use when triggers occur
+                timingMessages.push(msg.data.value());
+            }
         }
     }
 
@@ -675,6 +691,362 @@ struct Picoscope : public gr::Block<TPSImpl, gr::BlockingIO<true>, gr::Supported
         auto out = ps_state.errors.writer.reserve(1);
         out[0]   = { ps_state.produced_worker, ec };
         out.publish(1);
+    }
+
+    constexpr void
+    validateDesiredActualFrequency(double desiredFreq, double actualFreq) {
+        // In order to prevent exceptions/exit due to rounding errors, we dont directly
+        // compare actual_freq to desired_freq, but instead allow a difference up to 0.001%
+        constexpr double kMaxDiffPercentage = 0.001;
+        const double     diff               = actualFreq / desiredFreq - 1;
+        if (std::abs(diff) > kMaxDiffPercentage) {
+            throw std::runtime_error(fmt::format("Desired and actual frequency do not match. desired: {} actual: {}", desiredFreq, actualFreq));
+        }
+    }
+
+    constexpr int16_t
+    convertVoltageToRawLogicValue(double value) {
+        constexpr double kMaxLogicalVoltage = 5.0;
+
+        if (value > kMaxLogicalVoltage) {
+            throw std::invalid_argument(fmt::format("Maximum logical level is: {}, received: {}.", kMaxLogicalVoltage, value));
+        }
+        // Note max channel value not provided with PicoScope API, we use ext max value
+        return static_cast<int16_t>(value / kMaxLogicalVoltage * self().maxVoltage());
+    }
+
+    /*!
+     * Note this function has to be called after the call to the ps3000aSetChannel function,
+     * that is just befor the arm!!!
+     */
+    constexpr uint32_t
+    convertFrequencyToTimebase(int16_t handle, double desiredFreq, double &actualFreq) {
+        // It is assumed that the timebase is calculated like this:
+        // (timebase–2) / 125,000,000
+        // e.g. timeebase == 3 --> 8ns sample interval
+        //
+        // Note, for some devices, the above formula might be wrong! To overcome this
+        // limitation we use the ps3000aGetTimebase2 function to find the closest possible
+        // timebase. The below timebase estimate is therefore used as a fallback only.
+        auto     timeIntervalNS   = 1000000000.0 / desiredFreq;
+        uint32_t timebaseEstimate = (static_cast<uint32_t>(timeIntervalNS) / 8) + 2;
+
+        // In order to cover for all possible 30000 series devices, we use ps3000aGetTimebase2
+        // function to get step size in ns between timebase 3 and 4. Based on that the actual
+        // timebase is calculated.
+        int32_t              dummy;
+        std::array<float, 2> timeIntervalNS_34;
+
+        for (std::size_t i = 0; i < 2; i++) {
+            auto status = self().getTimebase2(handle, 3 + static_cast<uint32_t>(i), 1024, &timeIntervalNS_34[i], &dummy, 0);
+            if (status != PICO_OK) {
+#ifdef PROTO_PORT_DISABLED
+                d_logger->notice("timebase cannot be obtained: {}", get_error_message(status));
+                d_logger->notice("    estimated timebase will be used...");
+#endif
+
+                float timeIntervalNS_tmp;
+                status = self().getTimebase2(handle, timebaseEstimate, 1024, &timeIntervalNS_tmp, &dummy, 0);
+                if (status != PICO_OK) {
+                    throw std::runtime_error(fmt::format("Local time {}. Error: {}", timebaseEstimate, detail::getErrorMessage(status)));
+                }
+
+                actualFreq = 1000000000.0 / static_cast<double>(timeIntervalNS_tmp);
+                this->validateDesiredActualFrequency(desiredFreq, actualFreq);
+                return timebaseEstimate;
+            }
+        }
+
+        // Calculate steps between timebase 3 and 4 and correct start_timebase estimate based
+        // on that
+        auto step        = static_cast<double>(timeIntervalNS_34[1] - timeIntervalNS_34[0]);
+        timebaseEstimate = static_cast<uint32_t>((timeIntervalNS - static_cast<double>(timeIntervalNS_34[0])) / step) + 3;
+
+        // The below code iterates trought the neighbouring timebases in order to find the
+        // best match. In principle we could check only timebases on the left and right but
+        // since first three timebases are in most cases special we make search space a bit
+        // bigger.
+        const int                      searchSpace = 8;
+        std::array<float, searchSpace> timebases;
+        std::array<float, searchSpace> errorEstimates;
+
+        uint32_t                       startTimebase = timebaseEstimate > (searchSpace / 2) ? timebaseEstimate - (searchSpace / 2) : 0;
+
+        for (std::size_t i = 0; i < searchSpace; i++) {
+            float obtained_time_interval_ns;
+            auto  status = self().getTimebase2(handle, startTimebase + static_cast<uint32_t>(i), 1024, &obtained_time_interval_ns, &dummy, 0);
+            if (status != PICO_OK) {
+                // this timebase can't be used, lets set error estimate to something big
+                timebases[i]      = -1;
+                errorEstimates[i] = 10000000000.0;
+            } else {
+                timebases[i]      = obtained_time_interval_ns;
+                errorEstimates[i] = static_cast<float>(std::abs(timeIntervalNS - static_cast<double>(obtained_time_interval_ns)));
+            }
+        }
+
+        auto it       = std::min_element(&errorEstimates[0], &errorEstimates[0] + errorEstimates.size());
+        auto distance = std::distance(&errorEstimates[0], it);
+
+        assert(distance < searchSpace);
+
+        // update actual update rate and return timebase number
+        actualFreq = 1000000000.0 / static_cast<double>(timebases[static_cast<std::size_t>(distance)]);
+        this->validateDesiredActualFrequency(desiredFreq, actualFreq);
+        return static_cast<uint32_t>(startTimebase + distance);
+    }
+
+    Error
+    driver_initialize() {
+        PICO_STATUS status;
+
+        // Required to force sequence execution of open unit calls...
+        std::lock_guard initGuard{ g_init_mutex };
+
+        status = self().openUnit(this->ps_settings.serial_number);
+
+        // ignore ext. power not connected error/warning
+        if (status == PICO_POWER_SUPPLY_NOT_CONNECTED || status == PICO_USB3_0_DEVICE_NON_USB3_0_PORT) {
+            status = self().changePowerSource(this->ps_state.handle, status);
+            if (status == PICO_POWER_SUPPLY_NOT_CONNECTED || status == PICO_USB3_0_DEVICE_NON_USB3_0_PORT) {
+                status = self().changePowerSource(this->ps_state.handle, status);
+            }
+        }
+
+        if (status != PICO_OK) {
+            fmt::println(std::cerr, "open unit failed: {} ", detail::getErrorMessage(status));
+            return { status };
+        }
+
+        // maximum value is used for conversion to volts
+        status = self().maximumValue(this->ps_state.handle, &this->ps_state.max_value);
+        if (status != PICO_OK) {
+            self().closeUnit(this->ps_state.handle);
+            fmt::println(std::cerr, "maximumValue: {}", detail::getErrorMessage(status));
+            return { status };
+        }
+
+        return {};
+    }
+
+    Error
+    driver_close() {
+        if (this->ps_state.handle == -1) {
+            return {};
+        }
+
+        auto status           = self().closeUnit(this->ps_state.handle);
+        this->ps_state.handle = -1;
+
+        if (status != PICO_OK) {
+            fmt::println(std::cerr, "closeUnit: {}", detail::getErrorMessage(status));
+        }
+        return { status };
+    }
+
+    Error
+    driver_configure() {
+        int32_t maxSamples;
+        auto    status = self().memorySegments(this->ps_state.handle, static_cast<uint32_t>(this->ps_settings.rapid_block_nr_captures), &maxSamples);
+        if (status != PICO_OK) {
+            fmt::println(std::cerr, "MemorySegments: {}", detail::getErrorMessage(status));
+            return { status };
+        }
+
+        if constexpr (acquisitionMode == AcquisitionMode::RapidBlock) {
+            status = self().setNoOfCaptures(this->ps_state.handle, static_cast<uint32_t>(this->ps_settings.rapid_block_nr_captures));
+            if (status != PICO_OK) {
+                fmt::println(std::cerr, "SetNoOfCaptures: {}", detail::getErrorMessage(status));
+                return { status };
+            }
+        }
+
+        // configure analog channels
+        for (const auto &channel : this->ps_state.channels) {
+            const auto idx = self().convertToChannel(channel.id);
+            assert(idx);
+            const auto coupling = self().convertToCoupling(channel.settings.coupling);
+            const auto range    = self().convertToRange(channel.settings.range);
+
+            status              = self().setChannel(this->ps_state.handle, *idx, true, coupling, static_cast<TPSImpl::ChannelRangeType>(range), static_cast<float>(channel.settings.offset));
+            if (status != PICO_OK) {
+                fmt::println(std::cerr, "SetChannel (chan '{}'): {}", channel.id, detail::getErrorMessage(status));
+                return { status };
+            }
+        }
+
+        // apply trigger configuration
+        if (this->ps_settings.trigger.isAnalog() && acquisitionMode == AcquisitionMode::RapidBlock) {
+            const auto channel = self().convertToChannel(this->ps_settings.trigger.source);
+            assert(channel);
+            status = self().setSimpleTrigger(this->ps_state.handle,
+                                             true, // enable
+                                             *channel, convertVoltageToRawLogicValue(this->ps_settings.trigger.threshold), self().convertToThresholdDirection(this->ps_settings.trigger.direction),
+                                             0,   // delay
+                                             -1); // auto trigger
+            if (status != PICO_OK) {
+                fmt::println(std::cerr, "setSimpleTrigger: {}", detail::getErrorMessage(status));
+                return { status };
+            }
+        } else {
+            // disable triggers
+            for (int i = 0; i < self().maxChannel(); i++) {
+                typename TPSImpl::ConditionType cond;
+                cond.source    = static_cast<TPSImpl::ChannelType>(i);
+                cond.condition = self().conditionDontCare();
+                status         = self().setTriggerChannelConditions(this->ps_state.handle, &cond, 1, self().conditionsInfoClear());
+                if (status != PICO_OK) {
+                    fmt::println(std::cerr, "SetTriggerChannelConditionsV2: {}", detail::getErrorMessage(status));
+                    return { status };
+                }
+            }
+        }
+
+        // In order to validate desired frequency before startup
+        double actual_freq;
+        convertFrequencyToTimebase(this->ps_state.handle, this->ps_settings.sample_rate, actual_freq);
+
+        return {};
+    }
+
+    Error
+    driver_disarm() noexcept {
+        if (const auto status = self().driver_stop(this->ps_state.handle); status != PICO_OK) {
+            fmt::println(std::cerr, "Stop: {}", detail::getErrorMessage(status));
+            return { status };
+        }
+
+        return {};
+    }
+
+    Error
+    driver_arm() {
+        if constexpr (acquisitionMode == AcquisitionMode::RapidBlock) {
+            uint32_t    timebase   = this->convertFrequencyToTimebase(this->ps_state.handle, this->ps_settings.sample_rate, this->ps_state.actual_sample_rate);
+
+            static auto redirector = [](int16_t, PICO_STATUS status, void *vobj) { static_cast<decltype(this)>(vobj)->rapidBlockCallback({ status }); };
+
+            auto        status     = self().runBlock(this->ps_state.handle, static_cast<int32_t>(this->ps_settings.pre_samples), static_cast<int32_t>(this->ps_settings.post_samples),
+                                                     timebase, // timebase
+                                                     nullptr,  // time indispossed
+                                                     0,        // segment index
+                                                     static_cast<TPSImpl::BlockReadyType>(redirector), this);
+            if (status != PICO_OK) {
+                fmt::println(std::cerr, "RunBlock: {}", detail::getErrorMessage(status));
+                return { status };
+            }
+        } else {
+            using fair::picoscope::detail::kDriverBufferSize;
+            self().setBuffers(kDriverBufferSize, 0);
+
+            auto unit_int = self().convertFrequencyToTimeUnitsAndInterval(this->ps_settings.sample_rate, this->ps_state.actual_sample_rate);
+
+            auto status   = self().runStreaming(this->ps_state.handle,
+                                                &unit_int.interval, // sample interval
+                                                unit_int.unit,      // time unit of sample interval
+                                                0,                  // pre-triggersamples (unused)
+                                                static_cast<uint32_t>(kDriverBufferSize), false,
+                                                1, // downsampling factor // TODO reconsider if we need downsampling support
+                                                self().ratioNone(), static_cast<uint32_t>(kDriverBufferSize));
+
+            if (status != PICO_OK) {
+                fmt::println(std::cerr, "RunStreaming: {}", detail::getErrorMessage(status));
+                return { status };
+            }
+        }
+
+        return {};
+    }
+
+    Error
+    driver_poll() {
+        static auto redirector = [](int16_t handle, int32_t noOfSamples, uint32_t startIndex, int16_t overflow, uint32_t triggerAt, int16_t triggered, int16_t autoStop, void *vobj) {
+            std::ignore = handle;
+            std::ignore = triggerAt;
+            std::ignore = triggered;
+            std::ignore = autoStop;
+            static_cast<decltype(this)>(vobj)->streamingCallback(noOfSamples, startIndex, overflow);
+        };
+
+        const auto status = self().getStreamingLatestValues(this->ps_state.handle, static_cast<TPSImpl::StreamingReadyType>(redirector), this);
+        if (status == PICO_BUSY || status == PICO_DRIVER_FUNCTION) {
+            return {};
+        }
+        return { status };
+    }
+
+    fair::picoscope::GetValuesResult
+    driver_rapidBlockGetValues(std::size_t capture, std::size_t samples) {
+        if (const auto ec = self().setBuffers(samples, static_cast<uint32_t>(capture)); ec) {
+            return { ec, 0, 0 };
+        }
+
+        auto       nrSamples = static_cast<uint32_t>(samples);
+        int16_t    overflow  = 0;
+        const auto status    = self().getValues(this->ps_state.handle,
+                                                0, // offset
+                                                &nrSamples, 1, self().ratioNone(), static_cast<uint32_t>(capture), &overflow);
+        if (status != PICO_OK) {
+            fmt::println(std::cerr, "GetValues: {}", detail::getErrorMessage(status));
+            return { { status }, 0, 0 };
+        }
+
+        return { {}, static_cast<std::size_t>(nrSamples), overflow };
+    }
+
+    Error
+    setBuffers(size_t samples, uint32_t blockNumber) {
+        for (auto &channel : this->ps_state.channels) {
+            const auto channelIndex = self().convertToChannel(channel.id);
+            assert(channelIndex);
+
+            channel.driver_buffer.resize(std::max(samples, channel.driver_buffer.size()));
+            const auto status = self().setDataBuffer(this->ps_state.handle, *channelIndex, channel.driver_buffer.data(), static_cast<int32_t>(samples), blockNumber, self().ratioNone());
+
+            if (status != PICO_OK) {
+                fmt::println(std::cerr, "SetDataBuffer (chan {}): {}", static_cast<std::size_t>(*channelIndex), detail::getErrorMessage(status));
+                return { status };
+            }
+        }
+
+        return {};
+    }
+
+    std::string
+    getUnitInfoTopic(int16_t handle, PICO_INFO info) const {
+        std::array<int8_t, 40> line;
+        int16_t                requiredSize;
+
+        auto                   status = self().getUnitInfo(handle, line.data(), line.size(), &requiredSize, info);
+        if (status == PICO_OK) {
+            return std::string(reinterpret_cast<char *>(line.data()), static_cast<std::size_t>(requiredSize));
+        }
+
+        return {};
+    }
+
+    std::string
+    driver_driverVersion() const {
+        const std::string prefix  = "Picoscope Linux Driver, ";
+        auto              version = getUnitInfoTopic(this->ps_state.handle, PICO_DRIVER_VERSION);
+
+        if (auto i = version.find(prefix); i != std::string::npos) version.erase(i, prefix.length());
+        return version;
+    }
+
+    std::string
+    driver_hardwareVersion() const {
+        if (!this->ps_state.initialized) return {};
+        return getUnitInfoTopic(this->ps_state.handle, PICO_HARDWARE_VERSION);
+    }
+
+    std::optional<std::size_t>
+    driver_channelIdToIndex(std::string_view id) {
+        const auto channel = self().convertToChannel(id);
+        if (!channel) {
+            return {};
+        }
+        return static_cast<std::size_t>(*channel);
     }
 
     [[nodiscard]] constexpr auto &

--- a/blocklib/picoscope/Picoscope.hpp
+++ b/blocklib/picoscope/Picoscope.hpp
@@ -247,7 +247,10 @@ struct PicoscopeBlockingHelper<TPSImpl, true> {
 };
 
 template<PicoscopeOutput T, AcquisitionMode acquisitionMode, typename TPSImpl>
-struct Picoscope : public PicoscopeBlockingHelper<TPSImpl, acquisitionMode == AcquisitionMode::RapidBlock>::type {
+
+class Picoscope : public PicoscopeBlockingHelper<TPSImpl, acquisitionMode == AcquisitionMode::RapidBlock>::type {
+public:
+    using PicoscopeBlockingHelper<TPSImpl, acquisitionMode == AcquisitionMode::RapidBlock>::type::Block;
     A<std::string, "serial number">   serial_number;
     A<double, "sample rate", Visible> sample_rate = 10000.;
     // TODO any way to get custom enums into pmtv??
@@ -272,10 +275,12 @@ struct Picoscope : public PicoscopeBlockingHelper<TPSImpl, acquisitionMode == Ac
     detail::State<T>                                                  ps_state;
     detail::Settings                                                  ps_settings;
 
+private:
     std::mutex                                                        g_init_mutex;
-    std::size_t                                                       streamingSamples;
+    std::size_t                                                       streamingSamples = 0Z;
     std::queue<gr::property_map>                                      timingMessages;
 
+public:
     ~Picoscope() { stop(); }
 
     void
@@ -552,7 +557,7 @@ struct Picoscope : public PicoscopeBlockingHelper<TPSImpl, acquisitionMode == Ac
     }
 
     void
-    streamingCallback(int32_t nrSamplesSigned, uint32_t startIndex, int16_t overflow)
+    streamingCallback(int32_t nrSamplesSigned, uint32_t, int16_t overflow)
         requires(acquisitionMode == AcquisitionMode::Streaming)
     {
         streamingSamples = static_cast<std::size_t>(nrSamplesSigned);

--- a/blocklib/picoscope/Picoscope4000a.hpp
+++ b/blocklib/picoscope/Picoscope4000a.hpp
@@ -7,479 +7,238 @@
 
 namespace fair::picoscope {
 
-namespace detail {
-std::mutex g_init_mutex;
-
-std::string
-getUnitInfoTopic(int16_t handle, PICO_INFO info) {
-    std::array<int8_t, 40> line;
-    int16_t                requiredSize;
-
-    auto                   status = ps4000aGetUnitInfo(handle, line.data(), line.size(), &requiredSize, info);
-    if (status == PICO_OK) {
-        return std::string(reinterpret_cast<char *>(line.data()), static_cast<std::size_t>(requiredSize));
-    }
-
-    return {};
-}
-
-constexpr PS4000A_COUPLING
-convertToPs4000aCoupling(Coupling coupling) {
-    if (coupling == Coupling::AC_1M) return PS4000A_AC;
-    if (coupling == Coupling::DC_1M) return PS4000A_DC;
-    throw std::runtime_error(fmt::format("Unsupported coupling mode: {}", static_cast<int>(coupling)));
-}
-
-constexpr PS4000A_RANGE
-convertToPs4000aRange(double range) {
-    if (range == 0.01) return PS4000A_10MV;
-    if (range == 0.02) return PS4000A_20MV;
-    if (range == 0.05) return PS4000A_50MV;
-    if (range == 0.1) return PS4000A_100MV;
-    if (range == 0.2) return PS4000A_200MV;
-    if (range == 0.5) return PS4000A_500MV;
-    if (range == 1.0) return PS4000A_1V;
-    if (range == 2.0) return PS4000A_2V;
-    if (range == 5.0) return PS4000A_5V;
-    if (range == 10.0) return PS4000A_10V;
-    if (range == 20.0) return PS4000A_20V;
-    if (range == 50.0) return PS4000A_50V;
-    if (range == 100.0) return PS4000A_100V;
-    if (range == 200.0) return PS4000A_200V;
-    throw std::runtime_error(fmt::format("Range value not supported: {}", range));
-}
-
-constexpr void
-validateDesiredActualFrequencyPs4000a(double desiredFreq, double actualFreq) {
-    // In order to prevent exceptions/exit due to rounding errors, we dont directly
-    // compare actual_freq to desired_freq, but instead allow a difference up to 0.001%
-    constexpr double kMaxDiffPercentage = 0.001;
-    const double     diffPercent        = (actualFreq - desiredFreq) * 100 / desiredFreq;
-    if (abs(diffPercent) > kMaxDiffPercentage) {
-        throw std::runtime_error(fmt::format("Desired and actual frequency do not match. desired: {} actual: {}", desiredFreq, actualFreq));
-    }
-}
-
-constexpr int16_t
-convertVoltageToPs4000aRawLogicValue(double value) {
-    constexpr double kMaxLogicalVoltage = 5.0;
-
-    if (value > kMaxLogicalVoltage) {
-        throw std::invalid_argument(fmt::format("Maximum logical level is: {}, received: {}.", kMaxLogicalVoltage, value));
-    }
-    // Note max channel value not provided with PicoScope API, we use ext max value
-    return static_cast<int16_t>(value / kMaxLogicalVoltage * PS4000A_EXT_MAX_VALUE);
-}
-
-constexpr std::optional<PS4000A_CHANNEL>
-convertToPs4000aChannel(std::string_view source) {
-    if (source == "A") return PS4000A_CHANNEL_A;
-    if (source == "B") return PS4000A_CHANNEL_B;
-    if (source == "C") return PS4000A_CHANNEL_C;
-    if (source == "D") return PS4000A_CHANNEL_D;
-    if (source == "E") return PS4000A_CHANNEL_E;
-    if (source == "F") return PS4000A_CHANNEL_F;
-    if (source == "G") return PS4000A_CHANNEL_G;
-    if (source == "H") return PS4000A_CHANNEL_H;
-    if (source == "EXTERNAL") return PS4000A_EXTERNAL;
-    return {};
-}
-
-constexpr PS4000A_THRESHOLD_DIRECTION
-convertToPs4000aThresholdDirection(TriggerDirection direction) {
-    using enum TriggerDirection;
-    switch (direction) {
-    case Rising: return PS4000A_RISING;
-    case Falling: return PS4000A_FALLING;
-    case Low: return PS4000A_BELOW;
-    case High: return PS4000A_ABOVE;
-    default: throw std::runtime_error(fmt::format("Unsupported trigger direction: {}", static_cast<int>(direction)));
-    }
-};
-
-/*!
- * a structure used for streaming setup
- */
-struct Ps4000aUnitInterval {
-    PS4000A_TIME_UNITS unit;
-    uint32_t           interval;
-};
-
-constexpr Ps4000aUnitInterval
-convertFrequencyToPs4000aTimeUnitsAndInterval(double desired_freq, double &actual_freq) {
-    Ps4000aUnitInterval unint;
-
-    if (const auto interval = 1.0 / desired_freq; interval < 0.000001) {
-        unint.unit     = PS4000A_PS;
-        unint.interval = static_cast<uint32_t>(1000000000000.0 / desired_freq);
-        actual_freq    = 1000000000000.0 / unint.interval;
-    } else if (interval < 0.001) {
-        unint.unit     = PS4000A_NS;
-        unint.interval = static_cast<uint32_t>(1000000000.0 / desired_freq);
-        actual_freq    = 1000000000.0 / unint.interval;
-    } else if (interval < 0.1) {
-        unint.unit     = PS4000A_US;
-        unint.interval = static_cast<uint32_t>(1000000.0 / desired_freq);
-        actual_freq    = 1000000.0 / unint.interval;
-    } else {
-        unint.unit     = PS4000A_MS;
-        unint.interval = static_cast<uint32_t>(1000.0 / desired_freq);
-        actual_freq    = 1000.0 / unint.interval;
-    }
-    validateDesiredActualFrequencyPs4000a(desired_freq, actual_freq);
-    return unint;
-}
-
-/*!
- * Note this function has to be called after the call to the ps3000aSetChannel function,
- * that is just befor the arm!!!
- */
-constexpr uint32_t
-convertFrequencyToPs4000aTimebase(int16_t handle, double desiredFreq, double &actualFreq) {
-    // It is assumed that the timebase is calculated like this:
-    // (timebase–2) / 125,000,000
-    // e.g. timeebase == 3 --> 8ns sample interval
-    //
-    // Note, for some devices, the above formula might be wrong! To overcome this
-    // limitation we use the ps3000aGetTimebase2 function to find the closest possible
-    // timebase. The below timebase estimate is therefore used as a fallback only.
-    auto     timeIntervalNS   = 1000000000.0 / desiredFreq;
-    uint32_t timebaseEstimate = (static_cast<uint32_t>(timeIntervalNS) / 8) + 2;
-
-    // In order to cover for all possible 30000 series devices, we use ps3000aGetTimebase2
-    // function to get step size in ns between timebase 3 and 4. Based on that the actual
-    // timebase is calculated.
-    int32_t              dummy;
-    std::array<float, 2> timeIntervalNS_34;
-
-    for (std::size_t i = 0; i < 2; i++) {
-        auto status = ps4000aGetTimebase2(handle, 3 + static_cast<uint32_t>(i), 1024, &timeIntervalNS_34[i], &dummy, 0);
-        if (status != PICO_OK) {
-#ifdef PROTO_PORT_DISABLED
-            d_logger->notice("timebase cannot be obtained: {}", get_error_message(status));
-            d_logger->notice("    estimated timebase will be used...");
-#endif
-
-            float timeIntervalNS_tmp;
-            status = ps4000aGetTimebase2(handle, timebaseEstimate, 1024, &timeIntervalNS_tmp, &dummy, 0);
-            if (status != PICO_OK) {
-                throw std::runtime_error(fmt::format("Local time {}. Error: {}", timebaseEstimate, detail::getErrorMessage(status)));
-            }
-
-            actualFreq = 1000000000.0 / static_cast<double>(timeIntervalNS_tmp);
-            validateDesiredActualFrequencyPs4000a(desiredFreq, actualFreq);
-            return timebaseEstimate;
-        }
-    }
-
-    // Calculate steps between timebase 3 and 4 and correct start_timebase estimate based
-    // on that
-    auto step        = static_cast<double>(timeIntervalNS_34[1] - timeIntervalNS_34[0]);
-    timebaseEstimate = static_cast<uint32_t>((timeIntervalNS - static_cast<double>(timeIntervalNS_34[0])) / step) + 3;
-
-    // The below code iterates trought the neighbouring timebases in order to find the
-    // best match. In principle we could check only timebases on the left and right but
-    // since first three timebases are in most cases special we make search space a bit
-    // bigger.
-    const int                      searchSpace = 8;
-    std::array<float, searchSpace> timebases;
-    std::array<float, searchSpace> errorEstimates;
-
-    uint32_t                       startTimebase = timebaseEstimate > (searchSpace / 2) ? timebaseEstimate - (searchSpace / 2) : 0;
-
-    for (std::size_t i = 0; i < searchSpace; i++) {
-        float obtained_time_interval_ns;
-        auto  status = ps4000aGetTimebase2(handle, startTimebase + static_cast<uint32_t>(i), 1024, &obtained_time_interval_ns, &dummy, 0);
-        if (status != PICO_OK) {
-            // this timebase can't be used, lets set error estimate to something big
-            timebases[i]      = -1;
-            errorEstimates[i] = 10000000000.0;
-        } else {
-            timebases[i]      = obtained_time_interval_ns;
-            errorEstimates[i] = static_cast<float>(std::abs(timeIntervalNS - static_cast<double>(obtained_time_interval_ns)));
-        }
-    }
-
-    auto it       = std::min_element(&errorEstimates[0], &errorEstimates[0] + errorEstimates.size());
-    auto distance = std::distance(&errorEstimates[0], it);
-
-    assert(distance < searchSpace);
-
-    // update actual update rate and return timebase number
-    actualFreq = 1000000000.0 / static_cast<double>(timebases[static_cast<std::size_t>(distance)]);
-    validateDesiredActualFrequencyPs4000a(desiredFreq, actualFreq);
-    return static_cast<uint32_t>(startTimebase + distance);
-}
-
-} // namespace detail
-
-template<typename T>
-struct Picoscope4000a : public fair::picoscope::Picoscope<T, Picoscope4000a<T>> {
+template<typename T, AcquisitionMode acquisitionMode>
+struct Picoscope4000a : public fair::picoscope::Picoscope<T, acquisitionMode, Picoscope4000a<T, acquisitionMode>> {
     std::array<gr::PortOut<T>, 8> analog_out;
 
-    gr::work::Result
-    work(std::size_t requestedWork = 0) {
-        std::ignore = requestedWork;
-        return this->workImpl();
+    using ChannelType            = PS4000A_CHANNEL;
+    using ConditionType          = PS4000A_CONDITION;
+    using CouplingType           = PS4000A_COUPLING;
+    using RangeType              = PS4000A_RANGE;
+    using ChannelRangeType       = PICO_CONNECT_PROBE_RANGE;
+    using ThresholdDirectionType = PS4000A_THRESHOLD_DIRECTION;
+    using TriggerStateType       = PS4000A_TRIGGER_STATE;
+    using ConditionsInfoType     = PS4000A_CONDITIONS_INFO;
+    using TimeUnitsType          = PS4000A_TIME_UNITS;
+    using StreamingReadyType     = ps4000aStreamingReady;
+    using BlockReadyType         = ps4000aBlockReady;
+    using RatioModeType          = PS4000A_RATIO_MODE;
+
+    /*!
+     * a structure used for streaming setup
+     */
+    struct UnitInterval {
+        TimeUnitsType unit;
+        uint32_t      interval;
+    };
+
+    constexpr UnitInterval
+    convertFrequencyToTimeUnitsAndInterval(double desired_freq, double &actual_freq) {
+        UnitInterval unint;
+
+        if (const auto interval = 1.0 / desired_freq; interval < 0.000001) {
+            unint.unit     = PS4000A_PS;
+            unint.interval = static_cast<uint32_t>(1000000000000.0 / desired_freq);
+            actual_freq    = 1000000000000.0 / unint.interval;
+        } else if (interval < 0.001) {
+            unint.unit     = PS4000A_NS;
+            unint.interval = static_cast<uint32_t>(1000000000.0 / desired_freq);
+            actual_freq    = 1000000000.0 / unint.interval;
+        } else if (interval < 0.1) {
+            unint.unit     = PS4000A_US;
+            unint.interval = static_cast<uint32_t>(1000000.0 / desired_freq);
+            actual_freq    = 1000000.0 / unint.interval;
+        } else {
+            unint.unit     = PS4000A_MS;
+            unint.interval = static_cast<uint32_t>(1000.0 / desired_freq);
+            actual_freq    = 1000.0 / unint.interval;
+        }
+        this->validateDesiredActualFrequency(desired_freq, actual_freq);
+        return unint;
     }
 
-    Error
-    setBuffers(size_t samples, uint32_t blockNumber) {
-        for (auto &channel : this->ps_state.channels) {
-            const auto channelIndex = detail::convertToPs4000aChannel(channel.id);
-            assert(channelIndex);
-
-            channel.driver_buffer.resize(std::max(samples, channel.driver_buffer.size()));
-            const auto status = ps4000aSetDataBuffer(this->ps_state.handle, *channelIndex, channel.driver_buffer.data(), static_cast<int32_t>(samples), blockNumber, PS4000A_RATIO_MODE_NONE);
-
-            if (status != PICO_OK) {
-                fmt::println(std::cerr, "ps4000aSetDataBuffer (chan {}): {}", static_cast<std::size_t>(*channelIndex), detail::getErrorMessage(status));
-                return { status };
-            }
-        }
-
+    static constexpr std::optional<ChannelType>
+    convertToChannel(std::string_view source) {
+        if (source == "A") return PS4000A_CHANNEL_A;
+        if (source == "B") return PS4000A_CHANNEL_B;
+        if (source == "C") return PS4000A_CHANNEL_C;
+        if (source == "D") return PS4000A_CHANNEL_D;
+        if (source == "E") return PS4000A_CHANNEL_E;
+        if (source == "F") return PS4000A_CHANNEL_F;
+        if (source == "G") return PS4000A_CHANNEL_G;
+        if (source == "H") return PS4000A_CHANNEL_H;
+        if (source == "EXTERNAL") return PS4000A_EXTERNAL;
         return {};
     }
 
-    static constexpr float DRIVER_VERTICAL_PRECISION = 0.01f;
+    static constexpr CouplingType
+    convertToCoupling(Coupling coupling) {
+        if (coupling == Coupling::AC_1M) return PS4000A_AC;
+        if (coupling == Coupling::DC_1M) return PS4000A_DC;
+        throw std::runtime_error(fmt::format("Unsupported coupling mode: {}", static_cast<int>(coupling)));
+    }
 
-    static std::optional<std::size_t>
-    driver_channelIdToIndex(std::string_view id) {
-        const auto channel = detail::convertToPs4000aChannel(id);
-        if (!channel) {
-            return {};
+    static constexpr RangeType
+    convertToRange(double range) {
+        if (range == 0.01) return PS4000A_10MV;
+        if (range == 0.02) return PS4000A_20MV;
+        if (range == 0.05) return PS4000A_50MV;
+        if (range == 0.1) return PS4000A_100MV;
+        if (range == 0.2) return PS4000A_200MV;
+        if (range == 0.5) return PS4000A_500MV;
+        if (range == 1.0) return PS4000A_1V;
+        if (range == 2.0) return PS4000A_2V;
+        if (range == 5.0) return PS4000A_5V;
+        if (range == 10.0) return PS4000A_10V;
+        if (range == 20.0) return PS4000A_20V;
+        if (range == 50.0) return PS4000A_50V;
+        if (range == 100.0) return PS4000A_100V;
+        if (range == 200.0) return PS4000A_200V;
+        throw std::runtime_error(fmt::format("Range value not supported: {}", range));
+    }
+
+    constexpr ThresholdDirectionType
+    convertToThresholdDirection(TriggerDirection direction) {
+        using enum TriggerDirection;
+        switch (direction) {
+        case Rising: return PS4000A_RISING;
+        case Falling: return PS4000A_FALLING;
+        case Low: return PS4000A_BELOW;
+        case High: return PS4000A_ABOVE;
+        default: throw std::runtime_error(fmt::format("Unsupported trigger direction: {}", static_cast<int>(direction)));
         }
-        return static_cast<std::size_t>(*channel);
+    };
+
+    constexpr float
+    uncertainty() {
+        // https://www.picotech.com/oscilloscope/4000/picoscope-4000-specifications
+        return 0.0000045f;
     }
 
-    std::string
-    driver_driverVersion() const {
-        const std::string prefix  = "PS4000A Linux Driver, ";
-        auto              version = detail::getUnitInfoTopic(this->ps_state.handle, PICO_DRIVER_VERSION);
-
-        if (auto i = version.find(prefix); i != std::string::npos) version.erase(i, prefix.length());
-        return version;
+    PICO_STATUS
+    setDataBuffer(int16_t handle, ChannelType channel, int16_t *buffer, int32_t bufferLth, uint32_t segmentIndex, RatioModeType mode) {
+        return ps4000aSetDataBuffer(handle, channel, buffer, bufferLth, segmentIndex, mode);
     }
 
-    std::string
-    driver_hardwareVersion() const {
-        if (!this->ps_state.initialized) return {};
-        return detail::getUnitInfoTopic(this->ps_state.handle, PICO_HARDWARE_VERSION);
+    PICO_STATUS
+    getTimebase2(int16_t handle, uint32_t timebase, int32_t noSamples, float *timeIntervalNanoseconds, int32_t *maxSamples, uint32_t segmentIndex) {
+        return ps4000aGetTimebase2(handle, timebase, noSamples, timeIntervalNanoseconds, maxSamples, segmentIndex);
     }
 
-    fair::picoscope::GetValuesResult
-    driver_rapidBlockGetValues(std::size_t capture, std::size_t samples) {
-        if (const auto ec = setBuffers(samples, static_cast<uint32_t>(capture)); ec) {
-            return { ec, 0, 0 };
-        }
-
-        auto       nrSamples = static_cast<uint32_t>(samples);
-        int16_t    overflow  = 0;
-        const auto status    = ps4000aGetValues(this->ps_state.handle,
-                                                0, // offset
-                                                &nrSamples, 1, PS4000A_RATIO_MODE_NONE, static_cast<uint32_t>(capture), &overflow);
-        if (status != PICO_OK) {
-            fmt::println(std::cerr, "ps4000aGetValues: {}", detail::getErrorMessage(status));
-            return { { status }, 0, 0 };
-        }
-
-        return { {}, static_cast<std::size_t>(nrSamples), overflow };
-    }
-
-    Error
-    driver_initialize() {
-        PICO_STATUS status;
-
-        // Required to force sequence execution of open unit calls...
-        std::lock_guard initGuard{ detail::g_init_mutex };
-
+    PICO_STATUS
+    openUnit(const std::string &serial_number) {
         // take any if serial number is not provided (useful for testing purposes)
-        if (this->ps_settings.serial_number.empty()) {
-            status = ps4000aOpenUnit(&this->ps_state.handle, nullptr);
+        if (serial_number.empty()) {
+            return ps4000aOpenUnit(&this->ps_state.handle, nullptr);
         } else {
-            status = ps4000aOpenUnit(&this->ps_state.handle, const_cast<int8_t *>(reinterpret_cast<const int8_t *>(this->ps_settings.serial_number.data())));
+            return ps4000aOpenUnit(&this->ps_state.handle, const_cast<int8_t *>(reinterpret_cast<const int8_t *>(serial_number.data())));
         }
-
-        // ignore ext. power not connected error/warning
-        if (status == PICO_POWER_SUPPLY_NOT_CONNECTED || status == PICO_USB3_0_DEVICE_NON_USB3_0_PORT) {
-            status = ps4000aChangePowerSource(this->ps_state.handle, status);
-            if (status == PICO_POWER_SUPPLY_NOT_CONNECTED || status == PICO_USB3_0_DEVICE_NON_USB3_0_PORT) {
-                status = ps4000aChangePowerSource(this->ps_state.handle, status);
-            }
-        }
-
-        if (status != PICO_OK) {
-            fmt::println(std::cerr, "open unit failed: {} ", detail::getErrorMessage(status));
-            return { status };
-        }
-
-        // maximum value is used for conversion to volts
-        status = ps4000aMaximumValue(this->ps_state.handle, &this->ps_state.max_value);
-        if (status != PICO_OK) {
-            ps4000aCloseUnit(this->ps_state.handle);
-            fmt::println(std::cerr, "ps4000aMaximumValue: {}", detail::getErrorMessage(status));
-            return { status };
-        }
-
-        return {};
     }
 
-    Error
-    driver_close() {
-        if (this->ps_state.handle == -1) {
-            return {};
-        }
-
-        auto status           = ps4000aCloseUnit(this->ps_state.handle);
-        this->ps_state.handle = -1;
-
-        if (status != PICO_OK) {
-            fmt::println(std::cerr, "ps4000aCloseUnit: {}", detail::getErrorMessage(status));
-        }
-        return { status };
+    PICO_STATUS
+    closeUnit(int16_t handle) {
+        return ps4000aCloseUnit(handle);
     }
 
-    Error
-    driver_configure() {
-        int32_t maxSamples;
-        auto    status = ps4000aMemorySegments(this->ps_state.handle, static_cast<uint32_t>(this->ps_settings.rapid_block_nr_captures), &maxSamples);
-        if (status != PICO_OK) {
-            fmt::println(std::cerr, "ps4000aMemorySegments: {}", detail::getErrorMessage(status));
-            return { status };
-        }
-
-        if (this->ps_settings.acquisition_mode == AcquisitionMode::RapidBlock) {
-            status = ps4000aSetNoOfCaptures(this->ps_state.handle, static_cast<uint32_t>(this->ps_settings.rapid_block_nr_captures));
-            if (status != PICO_OK) {
-                fmt::println(std::cerr, "ps4000aSetNoOfCaptures: {}", detail::getErrorMessage(status));
-                return { status };
-            }
-        }
-
-        // configure analog channels
-        for (std::size_t i = 0; i <= PS4000A_MAX_CHANNELS; ++i) {
-            ps4000aSetChannel(this->ps_state.handle, static_cast<PS4000A_CHANNEL>(i), false, PS4000A_AC, PICO_X10_ACTIVE_PROBE_100MV, 0.);
-        }
-
-        for (const auto &channel : this->ps_state.channels) {
-            const auto idx = detail::convertToPs4000aChannel(channel.id);
-            assert(idx);
-            const auto coupling = detail::convertToPs4000aCoupling(channel.settings.coupling);
-            const auto range    = detail::convertToPs4000aRange(channel.settings.range);
-
-            status              = ps4000aSetChannel(this->ps_state.handle, *idx, true, coupling, static_cast<PICO_CONNECT_PROBE_RANGE>(range), static_cast<float>(channel.settings.offset));
-            if (status != PICO_OK) {
-                fmt::println(std::cerr, "ps4000aSetChannel (chan '{}'): {}", channel.id, detail::getErrorMessage(status));
-                return { status };
-            }
-        }
-
-        // apply trigger configuration
-        if (this->ps_settings.trigger.isAnalog() && this->ps_settings.acquisition_mode == AcquisitionMode::RapidBlock) {
-            const auto channel = detail::convertToPs4000aChannel(this->ps_settings.trigger.source);
-            assert(channel);
-            status = ps4000aSetSimpleTrigger(this->ps_state.handle,
-                                             true, // enable
-                                             *channel, detail::convertVoltageToPs4000aRawLogicValue(this->ps_settings.trigger.threshold),
-                                             detail::convertToPs4000aThresholdDirection(this->ps_settings.trigger.direction),
-                                             0,   // delay
-                                             -1); // auto trigger
-            if (status != PICO_OK) {
-                fmt::println(std::cerr, "ps4000aSetSimpleTrigger: {}", detail::getErrorMessage(status));
-                return { status };
-            }
-        } else {
-            // disable triggers
-            for (int i = 0; i < PS4000A_MAX_CHANNELS; i++) {
-                PS4000A_CONDITION cond;
-                cond.source    = static_cast<PS4000A_CHANNEL>(i);
-                cond.condition = PS4000A_CONDITION_DONT_CARE;
-                status         = ps4000aSetTriggerChannelConditions(this->ps_state.handle, &cond, 1, PS4000A_CLEAR);
-                if (status != PICO_OK) {
-                    fmt::println(std::cerr, "ps4000aSetTriggerChannelConditionsV2: {}", detail::getErrorMessage(status));
-                    return { status };
-                }
-            }
-        }
-
-        // In order to validate desired frequency before startup
-        double actual_freq;
-        detail::convertFrequencyToPs4000aTimebase(this->ps_state.handle, this->ps_settings.sample_rate, actual_freq);
-
-        return {};
+    PICO_STATUS
+    changePowerSource(int16_t handle, PICO_STATUS powerstate) {
+        return ps4000aChangePowerSource(handle, powerstate);
     }
 
-    Error
-    driver_arm() {
-        if (this->ps_settings.acquisition_mode == AcquisitionMode::RapidBlock) {
-            uint32_t    timebase   = detail::convertFrequencyToPs4000aTimebase(this->ps_state.handle, this->ps_settings.sample_rate, this->ps_state.actual_sample_rate);
-
-            static auto redirector = [](int16_t, PICO_STATUS status, void *vobj) { static_cast<Picoscope4000a *>(vobj)->rapidBlockCallback({ status }); };
-
-            auto        status     = ps4000aRunBlock(this->ps_state.handle, static_cast<int32_t>(this->ps_settings.pre_samples), static_cast<int32_t>(this->ps_settings.post_samples),
-                                                     timebase, // timebase
-                                                     nullptr,  // time indispossed
-                                                     0,        // segment index
-                                                     static_cast<ps4000aBlockReady>(redirector), this);
-            if (status != PICO_OK) {
-                fmt::println(std::cerr, "ps4000aRunBlock: {}", detail::getErrorMessage(status));
-                return { status };
-            }
-        } else {
-            using fair::picoscope::detail::kDriverBufferSize;
-            setBuffers(kDriverBufferSize, 0);
-
-            auto unit_int = detail::convertFrequencyToPs4000aTimeUnitsAndInterval(this->ps_settings.sample_rate, this->ps_state.actual_sample_rate);
-
-            auto status   = ps4000aRunStreaming(this->ps_state.handle,
-                                                &unit_int.interval, // sample interval
-                                                unit_int.unit,      // time unit of sample interval
-                                                0,                  // pre-triggersamples (unused)
-                                                static_cast<uint32_t>(kDriverBufferSize), false,
-                                                1, // downsampling factor // TODO reconsider if we need downsampling support
-                                                PS4000A_RATIO_MODE_NONE, static_cast<uint32_t>(kDriverBufferSize));
-
-            if (status != PICO_OK) {
-                fmt::println(std::cerr, "ps4000aRunStreaming: {}", detail::getErrorMessage(status));
-                return { status };
-            }
-        }
-
-        return {};
+    PICO_STATUS
+    maximumValue(int16_t handle, int16_t *value) {
+        return ps4000aMaximumValue(handle, value);
     }
 
-    Error
-    driver_disarm() noexcept {
-        if (const auto status = ps4000aStop(this->ps_state.handle); status != PICO_OK) {
-            fmt::println(std::cerr, "ps4000aStop: {}", detail::getErrorMessage(status));
-            return { status };
-        }
-
-        return {};
+    PICO_STATUS
+    memorySegments(int16_t handle, uint32_t nSegments, int32_t *nMaxSamples) {
+        return ps4000aMemorySegments(handle, nSegments, nMaxSamples);
     }
 
-    Error
-    driver_poll() {
-        static auto redirector = [](int16_t handle, int32_t noOfSamples, uint32_t startIndex, int16_t overflow, uint32_t triggerAt, int16_t triggered, int16_t autoStop, void *vobj) {
-            std::ignore = handle;
-            std::ignore = triggerAt;
-            std::ignore = triggered;
-            std::ignore = autoStop;
-            static_cast<Picoscope4000a *>(vobj)->streamingCallback(noOfSamples, startIndex, overflow);
-        };
-
-        const auto status = ps4000aGetStreamingLatestValues(this->ps_state.handle, static_cast<ps4000aStreamingReady>(redirector), this);
-        if (status == PICO_BUSY || status == PICO_DRIVER_FUNCTION) {
-            return {};
-        }
-        return { status };
+    PICO_STATUS
+    setNoOfCaptures(int16_t handle, uint32_t nCaptures) {
+        return ps4000aSetNoOfCaptures(handle, nCaptures);
     }
+
+    PICO_STATUS
+    setChannel(int16_t handle, ChannelType channel, int16_t enabled, CouplingType type, ChannelRangeType range, float analogOffset) {
+        return ps4000aSetChannel(handle, channel, enabled, type, range, analogOffset);
+    }
+
+    int
+    maxChannel() {
+        return PS4000A_MAX_CHANNELS;
+    }
+
+    int
+    maxVoltage() {
+        return PS4000A_EXT_MAX_VALUE;
+    }
+
+    CouplingType
+    analogCoupling() {
+        return PS4000A_AC;
+    }
+
+    TriggerStateType
+    conditionDontCare() {
+        return PS4000A_CONDITION_DONT_CARE;
+    }
+
+    ConditionsInfoType
+    conditionsInfoClear() {
+        return PS4000A_CLEAR;
+    }
+
+    PICO_STATUS
+    setSimpleTrigger(int16_t handle, int16_t enable, ChannelType source, int16_t threshold, ThresholdDirectionType direction, uint32_t delay, int16_t autoTriggerMs) {
+        return ps4000aSetSimpleTrigger(handle, enable, source, threshold, direction, delay, autoTriggerMs);
+    }
+
+    PICO_STATUS
+    setTriggerChannelConditions(int16_t handle, ConditionType *conditions, int16_t nConditions, ConditionsInfoType info) {
+        return ps4000aSetTriggerChannelConditions(handle, conditions, nConditions, info);
+    }
+
+    PICO_STATUS
+    driver_stop(int16_t handle) {
+        return ps4000aStop(handle);
+    }
+
+    PICO_STATUS
+    runBlock(int16_t handle, int32_t noOfPreTriggerSamples, int32_t noOfPostTriggerSamples, uint32_t timebase, int32_t *timeIndisposed, uint32_t segmentIndex, BlockReadyType ready, void *param) {
+        return ps4000aRunBlock(handle, noOfPreTriggerSamples, noOfPostTriggerSamples, timebase, timeIndisposed, segmentIndex, ready, param);
+    }
+
+    PICO_STATUS
+    runStreaming(int16_t handle, uint32_t *sampleInterval, TimeUnitsType timeUnits, uint32_t maxPreTriggerSamples, uint32_t maxPostTriggerSamples, int16_t autoStop, uint32_t downSampleRatio,
+                 RatioModeType downSampleRatioMode, uint32_t overviewBufferSize) {
+        return ps4000aRunStreaming(handle, sampleInterval, timeUnits, maxPreTriggerSamples, maxPostTriggerSamples, autoStop, downSampleRatio, downSampleRatioMode, overviewBufferSize);
+    }
+
+    RatioModeType
+    ratioNone() {
+        return PS4000A_RATIO_MODE_NONE;
+    }
+
+    PICO_STATUS
+    getStreamingLatestValues(int16_t handle, StreamingReadyType ready, void *param) {
+        return ps4000aGetStreamingLatestValues(handle, ready, param);
+    }
+
+    PICO_STATUS
+    getValues(int16_t handle, uint32_t startIndex, uint32_t *noOfSamples, uint32_t downSampleRatio, RatioModeType downSampleRatioMode, uint32_t segmentIndex, int16_t *overflow) {
+        return ps4000aGetValues(handle, startIndex, noOfSamples, downSampleRatio, downSampleRatioMode, segmentIndex, overflow);
+    }
+
+    PICO_STATUS
+    getUnitInfo(int16_t handle, int8_t *string, int16_t stringLength, int16_t *requiredSize, PICO_INFO info) const { return ps4000aGetUnitInfo(handle, string, stringLength, requiredSize, info); }
 };
 
 } // namespace fair::picoscope
 
-ENABLE_REFLECTION_FOR_TEMPLATE(fair::picoscope::Picoscope4000a, analog_out, serial_number, sample_rate, pre_samples, post_samples, acquisition_mode, rapid_block_nr_captures, streaming_mode_poll_rate,
-                               auto_arm, trigger_once, channel_ids, channel_names, channel_units, channel_ranges, channel_offsets, channel_couplings, trigger_source, trigger_threshold,
-                               trigger_direction, trigger_pin);
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, fair::picoscope::AcquisitionMode acquisitionMode), (fair::picoscope::Picoscope4000a<T, acquisitionMode>), analog_out, serial_number, sample_rate,
+                                    pre_samples, post_samples, acquisition_mode, rapid_block_nr_captures, streaming_mode_poll_rate, auto_arm, trigger_once, channel_ids, channel_names, channel_units,
+                                    channel_ranges, channel_offsets, channel_couplings, trigger_source, trigger_threshold, trigger_direction, trigger_pin);
 
 #endif

--- a/blocklib/picoscope/Picoscope4000a.hpp
+++ b/blocklib/picoscope/Picoscope4000a.hpp
@@ -10,6 +10,10 @@ namespace fair::picoscope {
 template<typename T, AcquisitionMode acquisitionMode>
 class Picoscope4000a : public fair::picoscope::Picoscope<T, acquisitionMode, Picoscope4000a<T, acquisitionMode>> {
 public:
+    using super_t = fair::picoscope::Picoscope<T, acquisitionMode, Picoscope4000a<T, acquisitionMode>>;
+
+    Picoscope4000a(gr::property_map props) : super_t(std::move(props)) {}
+
     std::array<gr::PortOut<T>, 8> analog_out;
 
     using ChannelType            = PS4000A_CHANNEL;

--- a/blocklib/picoscope/Picoscope4000a.hpp
+++ b/blocklib/picoscope/Picoscope4000a.hpp
@@ -8,7 +8,8 @@
 namespace fair::picoscope {
 
 template<typename T, AcquisitionMode acquisitionMode>
-struct Picoscope4000a : public fair::picoscope::Picoscope<T, acquisitionMode, Picoscope4000a<T, acquisitionMode>> {
+class Picoscope4000a : public fair::picoscope::Picoscope<T, acquisitionMode, Picoscope4000a<T, acquisitionMode>> {
+public:
     std::array<gr::PortOut<T>, 8> analog_out;
 
     using ChannelType            = PS4000A_CHANNEL;

--- a/blocklib/picoscope/Picoscope5000a.hpp
+++ b/blocklib/picoscope/Picoscope5000a.hpp
@@ -8,7 +8,8 @@
 namespace fair::picoscope {
 
 template<typename T, AcquisitionMode acquisitionMode>
-struct Picoscope5000a : public fair::picoscope::Picoscope<T, acquisitionMode, Picoscope5000a<T, acquisitionMode>> {
+class Picoscope5000a : public fair::picoscope::Picoscope<T, acquisitionMode, Picoscope5000a<T, acquisitionMode>> {
+public:
     std::array<gr::PortOut<T>, 4> analog_out;
 
     using ChannelType            = PS5000A_CHANNEL;

--- a/blocklib/picoscope/Picoscope5000a.hpp
+++ b/blocklib/picoscope/Picoscope5000a.hpp
@@ -1,0 +1,244 @@
+#ifndef FAIR_PICOSCOPE_PICOSCOPE5000A_HPP
+#define FAIR_PICOSCOPE_PICOSCOPE5000A_HPP
+
+#include <Picoscope.hpp>
+
+#include <ps5000aApi.h>
+
+namespace fair::picoscope {
+
+template<typename T, AcquisitionMode acquisitionMode>
+struct Picoscope5000a : public fair::picoscope::Picoscope<T, acquisitionMode, Picoscope5000a<T, acquisitionMode>> {
+    std::array<gr::PortOut<T>, 4> analog_out;
+
+    using ChannelType            = PS5000A_CHANNEL;
+    using ConditionType          = PS5000A_CONDITION;
+    using CouplingType           = PS5000A_COUPLING;
+    using RangeType              = PS5000A_RANGE;
+    using ChannelRangeType       = RangeType;
+    using ThresholdDirectionType = PS5000A_THRESHOLD_DIRECTION;
+    using TriggerStateType       = PS5000A_TRIGGER_STATE;
+    using ConditionsInfoType     = PS5000A_CONDITIONS_INFO;
+    using TimeUnitsType          = PS5000A_TIME_UNITS;
+    using StreamingReadyType     = ps5000aStreamingReady;
+    using BlockReadyType         = ps5000aBlockReady;
+    using RatioModeType          = PS5000A_RATIO_MODE;
+
+    /*!
+     * a structure used for streaming setup
+     */
+    struct UnitInterval {
+        TimeUnitsType unit;
+        uint32_t      interval;
+    };
+
+    constexpr UnitInterval
+    convertFrequencyToTimeUnitsAndInterval(double desired_freq, double &actual_freq) {
+        UnitInterval unint;
+
+        if (const auto interval = 1.0 / desired_freq; interval < 0.000001) {
+            unint.unit     = PS5000A_PS;
+            unint.interval = static_cast<uint32_t>(1000000000000.0 / desired_freq);
+            actual_freq    = 1000000000000.0 / unint.interval;
+        } else if (interval < 0.001) {
+            unint.unit     = PS5000A_NS;
+            unint.interval = static_cast<uint32_t>(1000000000.0 / desired_freq);
+            actual_freq    = 1000000000.0 / unint.interval;
+        } else if (interval < 0.1) {
+            unint.unit     = PS5000A_US;
+            unint.interval = static_cast<uint32_t>(1000000.0 / desired_freq);
+            actual_freq    = 1000000.0 / unint.interval;
+        } else {
+            unint.unit     = PS5000A_MS;
+            unint.interval = static_cast<uint32_t>(1000.0 / desired_freq);
+            actual_freq    = 1000.0 / unint.interval;
+        }
+        this->validateDesiredActualFrequency(desired_freq, actual_freq);
+        return unint;
+    }
+
+    static constexpr std::optional<ChannelType>
+    convertToChannel(std::string_view source) {
+        if (source == "A") return PS5000A_CHANNEL_A;
+        if (source == "B") return PS5000A_CHANNEL_B;
+        if (source == "C") return PS5000A_CHANNEL_C;
+        if (source == "D") return PS5000A_CHANNEL_D;
+        if (source == "EXTERNAL") return PS5000A_EXTERNAL;
+        return {};
+    }
+
+    static constexpr CouplingType
+    convertToCoupling(Coupling coupling) {
+        if (coupling == Coupling::AC_1M) return PS5000A_AC;
+        if (coupling == Coupling::DC_1M) return PS5000A_DC;
+        throw std::runtime_error(fmt::format("Unsupported coupling mode: {}", static_cast<int>(coupling)));
+    }
+
+    static constexpr RangeType
+    convertToRange(double range) {
+        if (range == 0.01) return PS5000A_10MV;
+        if (range == 0.02) return PS5000A_20MV;
+        if (range == 0.05) return PS5000A_50MV;
+        if (range == 0.1) return PS5000A_100MV;
+        if (range == 0.2) return PS5000A_200MV;
+        if (range == 0.5) return PS5000A_500MV;
+        if (range == 1.0) return PS5000A_1V;
+        if (range == 2.0) return PS5000A_2V;
+        if (range == 5.0) return PS5000A_5V;
+        if (range == 10.0) return PS5000A_10V;
+        if (range == 20.0) return PS5000A_20V;
+        if (range == 50.0) return PS5000A_50V;
+        throw std::runtime_error(fmt::format("Range value not supported: {}", range));
+    }
+
+    constexpr ThresholdDirectionType
+    convertToThresholdDirection(TriggerDirection direction) {
+        using enum TriggerDirection;
+        switch (direction) {
+        case Rising: return PS5000A_RISING;
+        case Falling: return PS5000A_FALLING;
+        case Low: return PS5000A_BELOW;
+        case High: return PS5000A_ABOVE;
+        default: throw std::runtime_error(fmt::format("Unsupported trigger direction: {}", static_cast<int>(direction)));
+        }
+    };
+
+    constexpr float
+    uncertainty() {
+        // https://www.picotech.com/oscilloscope/5000/picoscope-5000-specifications
+        return 0.0000120f;
+    }
+
+    PICO_STATUS
+    setDataBuffer(int16_t handle, ChannelType channel, int16_t *buffer, int32_t bufferLth, uint32_t segmentIndex, RatioModeType mode) {
+        return ps5000aSetDataBuffer(handle, channel, buffer, bufferLth, segmentIndex, mode);
+    }
+
+    PICO_STATUS
+    getTimebase2(int16_t handle, uint32_t timebase, int32_t noSamples, float *timeIntervalNanoseconds, int32_t *maxSamples, uint32_t segmentIndex) {
+        return ps5000aGetTimebase2(handle, timebase, noSamples, timeIntervalNanoseconds, maxSamples, segmentIndex);
+    }
+
+    PICO_STATUS
+    openUnit(const std::string &serial_number) {
+        // take any if serial number is not provided (useful for testing purposes)
+        if (serial_number.empty()) {
+            return ps5000aOpenUnit(&this->ps_state.handle, nullptr, PS5000A_DR_8BIT);
+        } else {
+            return ps5000aOpenUnit(&this->ps_state.handle, const_cast<int8_t *>(reinterpret_cast<const int8_t *>(serial_number.data())), PS5000A_DR_8BIT);
+        }
+    }
+
+    PICO_STATUS
+    closeUnit(int16_t handle) { return ps5000aCloseUnit(handle); }
+
+    PICO_STATUS
+    changePowerSource(int16_t handle, PICO_STATUS powerstate) { return ps5000aChangePowerSource(handle, powerstate); }
+
+    PICO_STATUS
+    maximumValue(int16_t handle, int16_t *value) { return ps5000aMaximumValue(handle, value); }
+
+    PICO_STATUS
+    memorySegments(int16_t handle, uint32_t nSegments, int32_t *nMaxSamples) { return ps5000aMemorySegments(handle, nSegments, nMaxSamples); }
+
+    PICO_STATUS
+    setNoOfCaptures(int16_t handle, uint32_t nCaptures) { return ps5000aSetNoOfCaptures(handle, nCaptures); }
+
+    PICO_STATUS
+    setChannel(int16_t handle, ChannelType channel, int16_t enabled, CouplingType type, ChannelRangeType range, float analogOffset) {
+        return ps5000aSetChannel(handle, channel, enabled, type, range, analogOffset);
+    }
+
+    int
+    maxChannel() {
+        return PS5000A_MAX_CHANNELS;
+    }
+
+    int
+    maxVoltage() {
+        return PS5000A_EXT_MAX_VALUE;
+    }
+
+    CouplingType
+    analogCoupling() {
+        return PS5000A_AC;
+    }
+
+    TriggerStateType
+    conditionDontCare() {
+        return PS5000A_CONDITION_DONT_CARE;
+    }
+
+    ConditionsInfoType
+    conditionsInfoClear() {
+        return PS5000A_CLEAR;
+    }
+
+    PICO_STATUS
+    setSimpleTrigger(int16_t handle, int16_t enable, ChannelType source, int16_t threshold, ThresholdDirectionType direction, uint32_t delay, int16_t autoTriggerMs) {
+        return ps5000aSetSimpleTrigger(handle, enable, source, threshold, direction, delay, autoTriggerMs);
+    }
+
+    PS5000A_TRIGGER_CONDITIONS
+    conditionsShim(ConditionType *condition, int16_t nConditions) {
+        PS5000A_TRIGGER_CONDITIONS result;
+        std::memset(&result, 0, sizeof(result));
+        for (int16_t i = 0; i < nConditions; ++i) {
+            auto cond = *(condition + i);
+            if (cond.source == PS5000A_CHANNEL_A) {
+                result.channelA = cond.condition;
+            } else if (cond.source == PS5000A_CHANNEL_B) {
+                result.channelB = cond.condition;
+            } else if (cond.source == PS5000A_CHANNEL_C) {
+                result.channelC = cond.condition;
+            } else if (cond.source == PS5000A_CHANNEL_D) {
+                result.channelD = cond.condition;
+            }
+        }
+        return result;
+    }
+
+    PICO_STATUS
+    setTriggerChannelConditions(int16_t handle, ConditionType *conditions, int16_t nConditions, ConditionsInfoType) {
+        PS5000A_TRIGGER_CONDITIONS conds = conditionsShim(conditions, nConditions);
+        return ps5000aSetTriggerChannelConditions(handle, &conds, 1);
+    }
+
+    PICO_STATUS
+    driver_stop(int16_t handle) { return ps5000aStop(handle); }
+
+    PICO_STATUS
+    runBlock(int16_t handle, int32_t noOfPreTriggerSamples, int32_t noOfPostTriggerSamples, uint32_t timebase, int32_t *timeIndisposed, uint32_t segmentIndex, BlockReadyType ready, void *param) {
+        return ps5000aRunBlock(handle, noOfPreTriggerSamples, noOfPostTriggerSamples, timebase, timeIndisposed, segmentIndex, ready, param);
+    }
+
+    PICO_STATUS
+    runStreaming(int16_t handle, uint32_t *sampleInterval, TimeUnitsType timeUnits, uint32_t maxPreTriggerSamples, uint32_t maxPostTriggerSamples, int16_t autoStop, uint32_t downSampleRatio,
+                 RatioModeType downSampleRatioMode, uint32_t overviewBufferSize) {
+        return ps5000aRunStreaming(handle, sampleInterval, timeUnits, maxPreTriggerSamples, maxPostTriggerSamples, autoStop, downSampleRatio, downSampleRatioMode, overviewBufferSize);
+    }
+
+    RatioModeType
+    ratioNone() {
+        return PS5000A_RATIO_MODE_NONE;
+    }
+
+    PICO_STATUS
+    getStreamingLatestValues(int16_t handle, StreamingReadyType ready, void *param) { return ps5000aGetStreamingLatestValues(handle, ready, param); }
+
+    PICO_STATUS
+    getValues(int16_t handle, uint32_t startIndex, uint32_t *noOfSamples, uint32_t downSampleRatio, RatioModeType downSampleRatioMode, uint32_t segmentIndex, int16_t *overflow) {
+        return ps5000aGetValues(handle, startIndex, noOfSamples, downSampleRatio, downSampleRatioMode, segmentIndex, overflow);
+    }
+
+    PICO_STATUS
+    getUnitInfo(int16_t handle, int8_t *string, int16_t stringLength, int16_t *requiredSize, PICO_INFO info) const { return ps5000aGetUnitInfo(handle, string, stringLength, requiredSize, info); }
+};
+
+} // namespace fair::picoscope
+
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, fair::picoscope::AcquisitionMode acquisitionMode), (fair::picoscope::Picoscope5000a<T, acquisitionMode>), analog_out, serial_number, sample_rate,
+                                    pre_samples, post_samples, acquisition_mode, rapid_block_nr_captures, streaming_mode_poll_rate, auto_arm, trigger_once, channel_ids, channel_names, channel_units,
+                                    channel_ranges, channel_offsets, channel_couplings, trigger_source, trigger_threshold, trigger_direction, trigger_pin);
+
+#endif

--- a/blocklib/picoscope/Picoscope5000a.hpp
+++ b/blocklib/picoscope/Picoscope5000a.hpp
@@ -10,6 +10,10 @@ namespace fair::picoscope {
 template<typename T, AcquisitionMode acquisitionMode>
 class Picoscope5000a : public fair::picoscope::Picoscope<T, acquisitionMode, Picoscope5000a<T, acquisitionMode>> {
 public:
+    using super_t = fair::picoscope::Picoscope<T, acquisitionMode, Picoscope5000a<T, acquisitionMode>>;
+
+    Picoscope5000a(gr::property_map props) : super_t(std::move(props)) {}
+
     std::array<gr::PortOut<T>, 4> analog_out;
 
     using ChannelType            = PS5000A_CHANNEL;

--- a/blocklib/picoscope/test/CMakeLists.txt
+++ b/blocklib/picoscope/test/CMakeLists.txt
@@ -7,4 +7,4 @@ function(add_ut_test_tool TEST_NAME)
     target_link_libraries(${TEST_NAME} PRIVATE gnuradio-core gr-testing fair-picoscope fair-helpers ut)
 endfunction()
 
-add_ut_test_tool(qa_Picoscope4000a)
+add_ut_test_tool(qa_Picoscope)

--- a/blocklib/picoscope/test/qa_Picoscope.cc
+++ b/blocklib/picoscope/test/qa_Picoscope.cc
@@ -95,8 +95,8 @@ testStreamingBasics() {
 
     expect(ge(sink.samples_seen, 80000UZ));
     expect(le(sink.samples_seen, 170000UZ));
-    expect(eq(tagMonitor.tags.size(), 1UZ));
-    const auto &tag = tagMonitor.tags[0];
+    expect(eq(tagMonitor._tags.size(), 1UZ));
+    const auto &tag = tagMonitor._tags[0];
     expect(eq(tag.index, int64_t{ 0 }));
     expect(eq(std::get<double>(tag.at(std::string(tag::SAMPLE_RATE.shortKey()))), static_cast<double>(kSampleRate)));
     expect(eq(std::get<std::string>(tag.at(std::string(tag::SIGNAL_NAME.shortKey()))), "Test signal"s));

--- a/blocklib/picoscope/test/qa_Picoscope4000a.cc
+++ b/blocklib/picoscope/test/qa_Picoscope4000a.cc
@@ -120,15 +120,15 @@ const boost::ut::suite Picoscope4000aTests = [] {
     };
 
     "streaming basics"_test = [] {
-        testStreamingBasics<float>();
-        testStreamingBasics<double>();
         testStreamingBasics<int16_t>();
+        testStreamingBasics<float>();
+        testStreamingBasics<gr::UncertainValue<float>>();
     };
 
     "rapid block basics"_test = [] {
-        testRapidBlockBasic<float>(1);
-        testRapidBlockBasic<double>(1);
         testRapidBlockBasic<int16_t>(1);
+        testRapidBlockBasic<float>(1);
+        testRapidBlockBasic<gr::UncertainValue<float>>(1);
     };
 
     "rapid block multiple captures"_test = [] { testRapidBlockBasic<float>(3); };


### PR DESCRIPTION
As discussed, this implements all of the following items:

- Restrict Picoscope value types to `int16_t`, `float` and `gr::UncertainValue<float>`
- Remove the custom `work()` implementation and port Picoscope to use `processBulk()`
- `BlockingIO` is now chosen at compile-time, based on whether the acquisition mode is streaming or rapidBlock
- Generalize and extend the Picoscope Block so that it can be used for all Picoscope variants.
- Incorporate timing messages received over the message port, when a trigger arrives
- Update to latest GR version
