### PR TITLE
Picoscope: integrate timing block with picoscope block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,9 @@ name: CMake
 
 on:
   push:
-    branches: [ dev-prototype ]
+    branches: [ main ]
   pull_request:
-    branches: [ dev-prototype ]
-  release:
-    types: [ created ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/blocklib/picoscope/test/CMakeLists.txt
+++ b/blocklib/picoscope/test/CMakeLists.txt
@@ -1,10 +1,19 @@
 # for manual usage, not run by ctest
 function(add_ut_test_tool TEST_NAME)
-    add_executable(${TEST_NAME} ${TEST_NAME}.cc)
-    target_compile_options(${TEST_NAME} PRIVATE -Wall)
-    target_link_options(${TEST_NAME} PRIVATE -Wall)
-    target_include_directories(${TEST_NAME} PRIVATE ${CMAKE_BINARY_DIR}/include ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-    target_link_libraries(${TEST_NAME} PRIVATE gnuradio-core gr-testing fair-picoscope fair-helpers ut)
+  add_executable(${TEST_NAME} ${TEST_NAME}.cc)
+  target_compile_options(${TEST_NAME} PRIVATE -Wall)
+  target_link_options(${TEST_NAME} PRIVATE -Wall)
+  target_include_directories(
+    ${TEST_NAME}
+    PRIVATE ${CMAKE_BINARY_DIR}/include ${CMAKE_CURRENT_BINARY_DIR}
+            ${CMAKE_CURRENT_SOURCE_DIR})
+  target_link_libraries(${TEST_NAME} PRIVATE gnuradio-core gr-testing
+                                             fair-picoscope fair-helpers ut)
 endfunction()
 
 add_ut_test_tool(qa_Picoscope)
+
+if(NOT EMSCRIPTEN AND NOT CLANG)
+  add_ut_test_tool(qa_PicoscopeTiming)
+  target_link_libraries(qa_PicoscopeTiming PRIVATE timing)
+endif()

--- a/blocklib/picoscope/test/qa_PicoscopeTiming.cc
+++ b/blocklib/picoscope/test/qa_PicoscopeTiming.cc
@@ -1,0 +1,171 @@
+#include <boost/ut.hpp>
+
+#include <gnuradio-4.0/Scheduler.hpp>
+#include <gnuradio-4.0/testing/TagMonitors.hpp>
+
+#include <HelperBlocks.hpp>
+#include <Picoscope4000a.hpp>
+#include <TimingSource.hpp>
+
+using namespace std::string_literals;
+
+namespace fair::picoscope::test {
+
+const boost::ut::suite PicoscopeTests = [] {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace fair::helpers;
+    using namespace fair::picoscope;
+
+    /**
+     * This is a special hardware test which needs a properly configured timing receiver with its IO1..3 connected to the Picoscopes input A..C.
+     * It will generate a known pattern of timing events, configure the timing receiver to generate pules on IO1 for each event and output a known pattern on IO2..3.
+     * The flowgraph in this test will then store the corresponding output samples and tags and check that the tags and output levels are correct.
+     */
+    "streamingWithTiming"_test = [] {
+        using namespace std::chrono;
+        using namespace std::chrono_literals;
+        using namespace boost::ut;
+
+        fmt::println("testStreamingBasicsWithTiming");
+
+        constexpr float kSampleRate = 80000.f; // [Hz]
+        constexpr auto  kDuration   = 2s;
+
+        gr::Graph flowGraph;
+        auto&     timingSrc = flowGraph.emplaceBlock<gr::timing::TimingSource>({
+            {"event_actions", std::vector<std::string>({"SIS100_RING:CMD_CUSTOM_DIAG_1->IO1(100,on,150,off),PUBLISH()"})}, // create a 50us pulse 100us after the timing event
+            {"sample_rate", 0.0f},                                                                                         //
+            {"verbose_console", false}                                                                                     //
+        });
+
+        auto& ps = flowGraph.emplaceBlock<Picoscope4000a<float, AcquisitionMode::Streaming>>({{
+            {"sample_rate", kSampleRate},                                               //
+            {"acquisition_mode", "Streaming"},                                          //
+            {"auto_arm", true},                                                         //
+            {"channel_ids", std::vector<std::string>{"A", "B", "C"}},                   //
+            {"channel_names", std::vector<std::string>{"Trigger", "IO2", "IO3"}},       //
+            {"channel_units", std::vector<std::string>{"V", "V", "V"}},                 //
+            {"channel_ranges", std::vector{5.0, 5.0, 5.0}},                             //
+            {"channel_offsets", std::vector{0.0, 0.0, 0.0}},                            //
+            {"channel_couplings", std::vector<std::string>{"DC_1M", "DC_1M", "DC_1M"}}, //
+            {"trigger_source", "A"},                                                    //
+            {"trigger_threshold", 1.7},                                                 //
+            {"trigger_direction", "Rising"}                                             //
+        }});
+
+        auto& sinkA = flowGraph.emplaceBlock<gr::testing::TagSink<float, gr::testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", true}}});
+        auto& sinkB = flowGraph.emplaceBlock<gr::testing::TagSink<float, gr::testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", true}}});
+        auto& sinkC = flowGraph.emplaceBlock<gr::testing::TagSink<float, gr::testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", true}}});
+
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out">(timingSrc).template to<"timingIn">(ps)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"analog_out", 0>(ps).template to<"in">(sinkA)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"analog_out", 1>(ps).template to<"in">(sinkB)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"analog_out", 2>(ps).template to<"in">(sinkC)));
+
+        // Explicitly start unit because it takes quite some time
+        expect(nothrow([&ps] { ps.start(); }));
+
+        std::jthread                                                 publishEvents([]() {
+            std::vector<std::pair<std::uint64_t, std::variant<Timing::Event, std::uint8_t>>> events{
+                                                                {500'000'000, std::uint8_t{0b000}},                                                    //
+                                                                {800'000'000, {Timing::Event(Timing::Event::fromGidEventnoBpidTag{}, 310, 286, 1)}},   //
+                                                                {1'000'000'000, std::uint8_t{0b010}},                                                  //
+                                                                {1'400'000'000, {Timing::Event(Timing::Event::fromGidEventnoBpidTag{}, 310, 286, 2)}}, //
+                                                                {1'500'000'000, std::uint8_t{0b100}},                                                  //
+                                                                {1'700'000'000, {Timing::Event(Timing::Event::fromGidEventnoBpidTag{}, 310, 286, 3)}}, //
+                                                                {2'000'000'000, std::uint8_t{0b110}},                                                  //
+                                                                {2'500'000'000, std::uint8_t{0b000}}                                                   //
+            };
+            std::size_t schedule_offset = 100'000'000;
+            fmt::print("start replay of test timing data\n");
+            Timing timing;
+            timing.saftAppName = fmt::format("qa_picoscope_timing_dispatcher_{}", getpid());
+            timing.initialize();
+            auto          outputs     = timing.receiver->getOutputs() | std::views::transform([&timing](auto kvp) {
+                auto [name, path] = kvp;
+                auto result       = saftlib::Output_Proxy::create(path, timing.saftSigGroup);
+                result->setOutputEnable(true);
+                result->WriteOutput(false);
+                return result;
+            }) | std::ranges::to<std::vector>();
+            std::uint64_t outputState = 0x0ull;
+            auto          start       = timing.currentTimeTAI() + schedule_offset;
+            std::this_thread::sleep_for(200ms);
+            for (auto& [schedule_dt, action] : events) {
+                while (start + schedule_dt > timing.currentTimeTAI() + schedule_offset) {
+                    timing.saftSigGroup.wait_for_signal(0);
+                }
+                if (std::holds_alternative<std::uint8_t>(action)) { // toggle outputs
+                    auto newState = std::get<std::uint8_t>(action);
+                    for (std::size_t j = 0; j < outputs.size(); j++) {
+                        if ((outputState & (0x1ull << j)) != ((newState) & (0x1ull << j))) {
+                            const bool state = ((newState) & (0x1ull << (j))) > 0;
+                            outputs[j]->WriteOutput(state);
+                        }
+                    }
+                    outputState = newState;
+                    // fmt::print("changed outputs: {:0b}\n", newState);
+                } else if (std::holds_alternative<Timing::Event>(action)) { // publish event
+                    auto event = std::get<Timing::Event>(action);
+                    event.time = schedule_dt;
+                    timing.injectEvent(event, start);
+                    timing.saftSigGroup.wait_for_signal(0);
+                    // fmt::print("sent event: id:{:#x}, gid:{}, evNo:{}, bpid:{}\n", event.id(), event.gid, event.eventNo, event.bpid);
+                } else {
+                    expect(false) << "unsupported event action";
+                }
+            }
+            fmt::print("finished replay of timing data\n");
+            return;
+        });
+        scheduler::Simple<scheduler::ExecutionPolicy::multiThreaded> sched{std::move(flowGraph)};
+        expect(sched.changeStateTo(lifecycle::State::INITIALISED).has_value());
+        expect(sched.changeStateTo(lifecycle::State::RUNNING).has_value());
+        std::this_thread::sleep_for(kDuration);
+        expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value());
+
+        const auto measuredRate = static_cast<double>(sinkA._nSamplesProduced) / duration<double>(kDuration).count();
+        fmt::println("Produced in worker: {}", ps.producedWorker());
+        fmt::println("Configured rate: {}, Measured rate: {} ({:.2f}%), Duration: {} ms", kSampleRate, static_cast<std::size_t>(measuredRate), measuredRate / static_cast<double>(kSampleRate) * 100., duration_cast<milliseconds>(kDuration).count());
+        fmt::println("Total: {}", sinkA._nSamplesProduced);
+
+        expect(ge(sinkA._nSamplesProduced, 80000UZ));
+        expect(le(sinkA._nSamplesProduced, 170000UZ));
+        if (sinkA._tags.size() == 1UZ) {
+            const auto& tag = sinkA._tags[0];
+            expect(eq(tag.index, 0UZ));
+            expect(eq(std::get<float>(tag.at(std::string(tag::SAMPLE_RATE.shortKey()))), kSampleRate));
+            expect(eq(std::get<std::string>(tag.at(std::string(tag::SIGNAL_NAME.shortKey()))), "Test signal"s));
+            expect(eq(std::get<std::string>(tag.at(std::string(tag::SIGNAL_UNIT.shortKey()))), "Test unit"s));
+            expect(eq(std::get<float>(tag.at(std::string(tag::SIGNAL_MIN.shortKey()))), 0.f));
+            expect(eq(std::get<float>(tag.at(std::string(tag::SIGNAL_MAX.shortKey()))), 5.f));
+        }
+        expect(std::ranges::equal(sinkA._tags | std::views::filter([](auto& t) { return t.map.contains("BPID"); })        // only consider timing events
+                                      | std::views::transform([](auto& t) { return std::get<uint16_t>(t.map["BPID"]); }), // get bpid (which is unique in this test)
+            std::vector<std::uint16_t>{1, 2, 3}));
+        auto timingEventSamplesFromTags = sinkA._tags | std::views::filter([](auto& t) { return t.map.contains("BPID"); }) // only consider timing events
+                                          | std::views::transform([](auto& t) { return t.index; })                         // get tag index
+                                          | std::ranges::to<std::vector>();
+        expect(eq(timingEventSamplesFromTags.size(), 3UZ)) << "expected to get exactly 3 timing tags";
+        expect(approx(static_cast<double>(timingEventSamplesFromTags[1] - timingEventSamplesFromTags[0]), (1'400'000'000 - 800'000'000) * 1e-9 * static_cast<double>(kSampleRate), 1.0)) << "sample distance between first and second tag does not match sample rate";
+        expect(approx(static_cast<double>(timingEventSamplesFromTags[2] - timingEventSamplesFromTags[0]), (1'700'000'000 - 800'000'000) * 1e-9 * static_cast<double>(kSampleRate), 1.0)) << "sample distance between first and third tag does not match sample rate";
+        expect(approx(sinkA._samples[timingEventSamplesFromTags[0] - 2], 0.0f, 1e-1f)) << "trigger channel should be zero ahead of timing event 0";
+        expect(approx(sinkA._samples[timingEventSamplesFromTags[0] + 2], 3.0f, 1e-1f)) << "trigger channel should be zero after of timing event 0";
+        expect(approx(sinkB._samples[timingEventSamplesFromTags[0]], 0.0f, 1e-1f)) << "state of IO2=inB should be LOW at timing event 0";
+        expect(approx(sinkC._samples[timingEventSamplesFromTags[0]], 0.0f, 1e-1f)) << "state of IO2=inB should be LOW at timing event 0";
+        expect(approx(sinkA._samples[timingEventSamplesFromTags[1] - 2], 0.0f, 1e-1f)) << "trigger channel should be zero ahead of timing event 1";
+        expect(approx(sinkA._samples[timingEventSamplesFromTags[1] + 2], 3.0f, 1e-1f)) << "trigger channel should be zero after of timing event 1";
+        expect(approx(sinkB._samples[timingEventSamplesFromTags[1]], 3.3f, 1e-1f)) << "state of IO2=inB should be HIGH at timing event 1";
+        expect(approx(sinkC._samples[timingEventSamplesFromTags[1]], 0.0f, 1e-1f)) << "state of IO2=inB should be LOW at timing event 1";
+        expect(approx(sinkA._samples[timingEventSamplesFromTags[2] - 2], 0.0f, 1e-1f)) << "trigger channel should be zero ahead of timing event 2";
+        expect(approx(sinkA._samples[timingEventSamplesFromTags[2] + 2], 3.0f, 1e-1f)) << "trigger channel should be zero after of timing event 2";
+        expect(approx(sinkB._samples[timingEventSamplesFromTags[2]], 0.0f, 1e-1f)) << "state of IO2=inB should be LOW at timing event 2";
+        expect(approx(sinkC._samples[timingEventSamplesFromTags[2]], 3.3f, 1e-1f)) << "state of IO2=inB should be HIGH at timing event 2";
+        fmt::print("timing events: {}\n", sinkA._tags | std::views::filter([](auto& t) { return t.map.contains("BPID"); }) | std::views::transform([](auto& t) { return std::pair(t.index, t.map); }));
+    };
+};
+
+} // namespace fair::picoscope::test
+
+int main() { /* tests are statically executed */ }

--- a/blocklib/timing/include/TimingSource.hpp
+++ b/blocklib/timing/include/TimingSource.hpp
@@ -375,7 +375,7 @@ it accordingly using the `saft-io-ctl` utility.
             tag.map.emplace("BPC-START", event.flagBpcStart);
             tag.map.emplace("BPCID", event.bpcid);
             tag.map.emplace("BPCTS", event.bpcts);
-            tag.map.emplace(tag::TRIGGER_OFFSET, 0); // TODO: correctly calculate offset
+            tag.map.emplace(tag::TRIGGER_OFFSET, 0); // The trigger offset has to be set either when publishing at fixed sample rate or when adding the tag to a sample e.g. in the picoscope block
         }
         return tag;
     }

--- a/blocklib/timing/include/timing.hpp
+++ b/blocklib/timing/include/timing.hpp
@@ -98,18 +98,18 @@ public:
         uint8_t  fid = 1; // 4
         uint16_t gid;     // 12
         uint16_t eventNo; // 12
-        bool     flagBeamin;
-        bool     flagBpcStart;
-        bool     flagReserved1;
-        bool     flagReserved2;
-        uint16_t sid;  // 12
-        uint16_t bpid; // 14
-        bool     reserved;
-        bool     reqNoBeam;
-        uint8_t  virtAcc; // 4
+        bool     flagBeamin{};
+        bool     flagBpcStart{};
+        bool     flagReserved1{};
+        bool     flagReserved2{};
+        uint16_t sid{}; // 12
+        uint16_t bpid;  // 14
+        bool     reserved{};
+        bool     reqNoBeam{};
+        uint8_t  virtAcc{}; // 4
         // param - 64
-        uint32_t bpcid; // 22
-        uint64_t bpcts; // 42
+        uint32_t bpcid{}; // 22
+        uint64_t bpcts{}; // 42
         // timing system
         uint64_t time     = 0;
         uint64_t executed = 0;
@@ -140,6 +140,9 @@ public:
               fid{extractField<uint8_t, 60, 4>(id)}, gid{extractField<uint16_t, 48, 12>(id)}, eventNo{extractField<uint16_t, 36, 12>(id)}, flagBeamin{extractField<bool, 35, 1>(id)}, flagBpcStart{extractField<bool, 34, 1>(id)}, flagReserved1{extractField<bool, 33, 1>(id)}, flagReserved2{extractField<bool, 32, 1>(id)}, sid{extractField<uint16_t, 20, 12>(id)}, bpid{extractField<uint16_t, 6, 14>(id)}, reserved{extractField<bool, 5, 1>(id)}, reqNoBeam{extractField<bool, 4, 1>(id)}, virtAcc{extractField<uint8_t, 0, 4>(id)},
               // param
               bpcid{extractField<uint32_t, 42, 22>(param)}, bpcts{extractField<uint64_t, 0, 42>(param)}, time{timestamp}, executed{_executed}, flags{_flags}, isIo{_isIo} {}
+
+        struct fromGidEventnoBpidTag {};
+        Event(const fromGidEventnoBpidTag, const uint16_t _gid, const uint16_t _eventNo, const uint16_t _bpid) : gid{_gid}, eventNo{_eventNo}, bpid{_bpid} {}
 
         [[nodiscard]] uint64_t id() const {
             // clang-format:off

--- a/blocklib/timing/test/qa_timingSource.cpp
+++ b/blocklib/timing/test/qa_timingSource.cpp
@@ -3,7 +3,6 @@
 #include <fmt/core.h>
 #include <gnuradio-4.0/Scheduler.hpp>
 #include <gnuradio-4.0/basic/ConverterBlocks.hpp>
-#include <gnuradio-4.0/testing/ImChartMonitor.hpp>
 #include <gnuradio-4.0/testing/TagMonitors.hpp>
 #include <latch>
 


### PR DESCRIPTION
This allows the picoscope in streaming mode to match tags received from a TimingSource block and add them to the correct output port samples.
It also contains a unit-test which checks that the tags are propagated to the correct samples.

Open issues:
- Handling multiple tags within one trigger pulse width, which might not always be predictable
- Handling events where the corresponding trigger was not generated or detected (by having a timeout compared to the local clock)
- rapid block mode
- how to handle waiting for timing tags with low latency but without busy polling.