### PR TITLE
CI: create a separate docker Image based on the gr4 build image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,65 @@ on:
     branches: [ main ]
 
 jobs:
+  buildAndPublishDocker:
+    name: "Update the docker container if it is modified"
+    runs-on: "ubuntu-latest"
+    outputs:
+      container: ${{ steps.docker-label.outputs.label }}
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'push'
+        with:
+          fetch-depth: 0
+
+      - name: Check if dockerfile was modified
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+             docker:
+               - 'docker/Dockerfile'
+
+      #TODO: check if the underlying docker container is newer than the current one
+
+      - name: Set up Docker Label
+        id: docker-label
+        run: |
+          if [ ${{ steps.changes.outputs.docker == 'true' && github.event_name != 'push' }} = "true" ]; then
+            echo "label=ghcr.io/fair-acc/gr-digitizers-build-container:${GITHUB_HEAD_REF/\//-}" >> "$GITHUB_OUTPUT"
+          else
+            echo "label=ghcr.io/fair-acc/gr-digitizers-build-container:latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.docker == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        if: steps.changes.outputs.docker == 'true'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v5
+        if: steps.changes.outputs.docker == 'true'
+        with:
+          context: "{{defaultContext}}:docker"
+          push: true
+          tags: ${{ steps.docker-label.outputs.label }}
+
   build:
     name: "${{ matrix.compiler.cc }} | ${{ matrix.cmake-build-type }}"
+    needs: buildAndPublishDocker
     runs-on: "ubuntu-latest"
     container:
-      image: "ghcr.io/fair-acc/gr4-build-container:latest"
+      image: "${{ needs.buildAndPublishDocker.outputs.container }}"
     strategy:
       fail-fast: false
       matrix:
@@ -38,47 +92,6 @@ jobs:
         with:
           path: "/__w/gr-digitizers/build/_deps"
           key: "${{ matrix.compiler.cc }}-${{ matrix.cmake-build-type }}-${{ hashFiles('CMakeLists.txt') }}"
-
-      - name: "Install pkg-config"
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install build-essential pkg-config
-
-      - name: "Install timing system dependencies: etherbone"
-        if: matrix.compiler.cmake_wrapper == null
-        shell: bash
-        run: |
-          sudo apt-get -y install build-essential autoconf automake libtool
-          git clone --branch v2.1.3 --depth=1 https://ohwr.org/project/etherbone-core.git
-          cd etherbone-core/api
-          touch ChangeLog # add an empty changelog file which is required by autotools
-          sed -e "s%AC_MSG_ERROR%AC_MSG_NOTICE%g" -i configure.ac
-          autoreconf -i
-          ./configure
-          make -j
-          sudo make install
-
-      - name: "Install timing system dependencies: saftlib"
-        if: matrix.compiler.cmake_wrapper == null
-        shell: bash
-        run: |
-          sudo apt-get -y install libsigc++-2.0-dev libxslt1-dev libboost-all-dev
-          git clone --branch v3.0.3 --depth=1 https://github.com/GSI-CS-CO/saftlib.git
-          cd saftlib
-          ./autogen.sh
-          ./configure
-          make
-          sudo make install
-
-      - name: Install picoscope libraries
-        if: matrix.compiler.cmake_wrapper == null
-        run: |
-          # https://www.picotech.com/downloads/linux
-          wget -O - https://labs.picotech.com/Release.gpg.key|sudo apt-key add -
-          sudo add-apt-repository 'deb https://labs.picotech.com/rc/picoscope7/debian/ picoscope main'
-          sudo apt update
-          sudo apt install -y udev libusb-1.0-0-dev libps3000a libps4000a libps5000a libps6000 libps6000a libx11-dev libgl1-mesa-dev libsdl2-dev || true # ignore udev errors in post install because of udev in container
 
       - name: Configure
         if: matrix.compiler.cmake_wrapper == null
@@ -115,7 +128,7 @@ jobs:
       - name: execute tests
         if: matrix.compiler.cc != 'gcc-14' || matrix.cmake-build-type != 'Debug'
         shell: bash
-        run: | 
+        run: |
           cd ../build
           ctest --output-on-failure
 
@@ -136,3 +149,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: sonar-scanner
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,47 @@
+FROM ghcr.io/fair-acc/gr4-build-container:latest
+LABEL authors="akrimm"
+
+# Install pkg-config
+RUN sudo apt-get update && sudo apt-get -y install build-essential pkg-config && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
+
+# Install timing system dependencies: etherbone"
+RUN sudo apt-get update \
+    && sudo apt-get -y install build-essential autoconf automake libtool \
+    && cd $(mktmp -d) \
+    && git clone --branch v2.1.3 --depth=1 https://ohwr.org/project/etherbone-core.git \
+    && cd etherbone-core/api \
+    && touch ChangeLog \
+    && sed -e "s%AC_MSG_ERROR%AC_MSG_NOTICE%g" -i configure.ac \
+    && autoreconf -i \
+    && ./configure \
+    && make -j \
+    && sudo make install \
+    && rm -rf ./* \
+    && sudo apt-get clean \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+# Install timing system dependencies: saftlib"
+RUN sudo apt-get update \
+    && sudo apt-get -y install libsigc++-2.0-dev libxslt1-dev libboost-all-dev \
+    && cd $(mktmp -d) \
+    && git clone --branch v3.0.3 --depth=1 https://github.com/GSI-CS-CO/saftlib.git \
+    && cd saftlib \
+    && ./autogen.sh \
+    && ./configure \
+    && make \
+    && sudo make install \
+    && rm -rf ./* \
+    && sudo apt-get clean \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+# Install picoscope libraries https://www.picotech.com/downloads/linux
+RUN sudo apt-get update \
+    && ( wget -O - https://labs.picotech.com/Release.gpg.key|sudo apt-key add - ) \
+    && sudo add-apt-repository 'deb https://labs.picotech.com/rc/picoscope7/debian/ picoscope main' \
+    && sudo apt update \
+    && ( sudo apt install -y udev libusb-1.0-0-dev libps3000a libps4000a libps5000a libps6000 libps6000a libx11-dev libgl1-mesa-dev libsdl2-dev || true ) \
+    && sudo apt-get clean \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+USER user
+ENTRYPOINT ["/bin/bash", "-c"]


### PR DESCRIPTION
This should reduce build time and also allow to locally reuse this build environment.
For now this will not recognize changes in the gr4 Dockerfile, so the layer in this repo will not be automatically rebuilt.

This would probably need to query the upload timestamps of the gr4 and digitizer builder images and verifying that the gr4 image is older.