### PR TITLE
Update Picoscope block

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set(ENABLE_TESTING OFF)
 FetchContent_Declare(
   gnuradio4
   GIT_REPOSITORY https://github.com/fair-acc/gnuradio4.git
-  GIT_TAG 1c48239fae93a57b18978ac517e348f1ed908ae0 # main as of 2025-01-16
+  GIT_TAG 3b58693a870ce32b24d43ed8a58ae2fcdd9a5ae6 # main as of 2025-02-19
 )
 
 FetchContent_Declare(

--- a/blocklib/picoscope/Picoscope4000a.hpp
+++ b/blocklib/picoscope/Picoscope4000a.hpp
@@ -14,7 +14,7 @@ public:
 
     Picoscope4000a(gr::property_map props) : super_t(std::move(props)) {}
 
-    std::vector<gr::PortOut<T>> analog_out{8};
+    std::vector<gr::PortOut<T>> out{8};
 
     using ChannelType            = PS4000A_CHANNEL;
     using ConditionType          = PS4000A_CONDITION;
@@ -29,7 +29,7 @@ public:
     using BlockReadyType         = ps4000aBlockReady;
     using RatioModeType          = PS4000A_RATIO_MODE;
 
-    GR_MAKE_REFLECTABLE(Picoscope4000a, analog_out);
+    GR_MAKE_REFLECTABLE(Picoscope4000a, out);
 
     /*!
      * a structure used for streaming setup
@@ -39,7 +39,7 @@ public:
         uint32_t      interval;
     };
 
-    constexpr UnitInterval convertFrequencyToTimeUnitsAndInterval(double desired_freq, double& actual_freq) {
+    constexpr UnitInterval convertFrequencyToTimeUnitsAndInterval(float desired_freq, float& actual_freq) {
         UnitInterval unint;
 
         if (const auto interval = 1.0 / desired_freq; interval < 0.000001) {
@@ -104,47 +104,47 @@ public:
         throw std::runtime_error(fmt::format("Unsupported coupling mode: {}", static_cast<int>(coupling)));
     }
 
-    static constexpr RangeType convertToRange(double range) {
-        if (range == 0.01) {
+    static constexpr RangeType convertToRange(float range) {
+        if (range == 0.01f) {
             return PS4000A_10MV;
         }
-        if (range == 0.02) {
+        if (range == 0.02f) {
             return PS4000A_20MV;
         }
-        if (range == 0.05) {
+        if (range == 0.05f) {
             return PS4000A_50MV;
         }
-        if (range == 0.1) {
+        if (range == 0.1f) {
             return PS4000A_100MV;
         }
-        if (range == 0.2) {
+        if (range == 0.2f) {
             return PS4000A_200MV;
         }
-        if (range == 0.5) {
+        if (range == 0.5f) {
             return PS4000A_500MV;
         }
-        if (range == 1.0) {
+        if (range == 1.f) {
             return PS4000A_1V;
         }
-        if (range == 2.0) {
+        if (range == 2.f) {
             return PS4000A_2V;
         }
-        if (range == 5.0) {
+        if (range == 5.f) {
             return PS4000A_5V;
         }
-        if (range == 10.0) {
+        if (range == 10.f) {
             return PS4000A_10V;
         }
-        if (range == 20.0) {
+        if (range == 20.f) {
             return PS4000A_20V;
         }
-        if (range == 50.0) {
+        if (range == 50.f) {
             return PS4000A_50V;
         }
-        if (range == 100.0) {
+        if (range == 100.f) {
             return PS4000A_100V;
         }
-        if (range == 200.0) {
+        if (range == 200.f) {
             return PS4000A_200V;
         }
         throw std::runtime_error(fmt::format("Range value not supported: {}", range));

--- a/blocklib/picoscope/Picoscope5000a.hpp
+++ b/blocklib/picoscope/Picoscope5000a.hpp
@@ -14,9 +14,9 @@ public:
 
     Picoscope5000a(gr::property_map props) : super_t(std::move(props)) {}
 
-    std::vector<gr::PortOut<T>> analog_out{4};
+    std::vector<gr::PortOut<T>> out{4};
 
-    GR_MAKE_REFLECTABLE(Picoscope5000a, analog_out);
+    GR_MAKE_REFLECTABLE(Picoscope5000a, out);
 
     using ChannelType            = PS5000A_CHANNEL;
     using ConditionType          = PS5000A_CONDITION;
@@ -39,7 +39,7 @@ public:
         uint32_t      interval;
     };
 
-    constexpr UnitInterval convertFrequencyToTimeUnitsAndInterval(double desired_freq, double& actual_freq) {
+    constexpr UnitInterval convertFrequencyToTimeUnitsAndInterval(float desired_freq, float& actual_freq) {
         UnitInterval unint;
 
         if (const auto interval = 1.0 / desired_freq; interval < 0.000001) {
@@ -92,41 +92,41 @@ public:
         throw std::runtime_error(fmt::format("Unsupported coupling mode: {}", static_cast<int>(coupling)));
     }
 
-    static constexpr RangeType convertToRange(double range) {
-        if (range == 0.01) {
+    static constexpr RangeType convertToRange(float range) {
+        if (range == 0.0f) {
             return PS5000A_10MV;
         }
-        if (range == 0.02) {
+        if (range == 0.02f) {
             return PS5000A_20MV;
         }
-        if (range == 0.05) {
+        if (range == 0.05f) {
             return PS5000A_50MV;
         }
-        if (range == 0.1) {
+        if (range == 0.1f) {
             return PS5000A_100MV;
         }
-        if (range == 0.2) {
+        if (range == 0.2f) {
             return PS5000A_200MV;
         }
-        if (range == 0.5) {
+        if (range == 0.5f) {
             return PS5000A_500MV;
         }
-        if (range == 1.0) {
+        if (range == 1.f) {
             return PS5000A_1V;
         }
-        if (range == 2.0) {
+        if (range == 2.f) {
             return PS5000A_2V;
         }
-        if (range == 5.0) {
+        if (range == 5.f) {
             return PS5000A_5V;
         }
-        if (range == 10.0) {
+        if (range == 10.f) {
             return PS5000A_10V;
         }
-        if (range == 20.0) {
+        if (range == 20.f) {
             return PS5000A_20V;
         }
-        if (range == 50.0) {
+        if (range == 50.f) {
             return PS5000A_50V;
         }
         throw std::runtime_error(fmt::format("Range value not supported: {}", range));

--- a/blocklib/picoscope/test/CMakeLists.txt
+++ b/blocklib/picoscope/test/CMakeLists.txt
@@ -12,6 +12,7 @@ function(add_ut_test_tool TEST_NAME)
 endfunction()
 
 add_ut_test_tool(qa_Picoscope)
+add_ut_test_tool(qa_PicoscopePerformanceMonitor)
 
 if(NOT EMSCRIPTEN AND NOT CLANG)
   add_ut_test_tool(qa_PicoscopeTiming)

--- a/blocklib/picoscope/test/qa_Picoscope.cc
+++ b/blocklib/picoscope/test/qa_Picoscope.cc
@@ -27,21 +27,38 @@ void testRapidBlockBasic(std::size_t nrCaptures) {
 
     fmt::println("testRapidBlockBasic - {}", gr::meta::type_name<T>());
 
-    constexpr std::size_t kPreSamples  = 33;
-    constexpr std::size_t kPostSamples = 1000;
-    const auto            totalSamples = nrCaptures * (kPreSamples + kPostSamples);
+    constexpr gr::Size_t kPreSamples  = 33;
+    constexpr gr::Size_t kPostSamples = 1000;
+    const gr::Size_t     totalSamples = nrCaptures * (kPreSamples + kPostSamples);
 
     Graph flowGraph;
-    auto& ps = flowGraph.emplaceBlock<PicoscopeT<T, AcquisitionMode::RapidBlock>>({{{"sample_rate", 10000.f}, {"pre_samples", kPreSamples}, {"post_samples", kPostSamples}, {"acquisition_mode", "RapidBlock"}, {"rapid_block_nr_captures", nrCaptures}, {"auto_arm", true}, {"trigger_once", true}, {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector{5.}}, {"channel_couplings", std::vector<std::string>{"AC_1M"}}}});
+    auto& ps = flowGraph.emplaceBlock<PicoscopeT<T, AcquisitionMode::RapidBlock>>({{{"sample_rate", 10000.f},                                      //
+        {"pre_samples", kPreSamples}, {"post_samples", kPostSamples}, {"acquisition_mode", "RapidBlock"}, {"rapid_block_nr_captures", nrCaptures}, //
+        {"auto_arm", true}, {"trigger_once", true}, {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}},   //
+        {"channel_couplings", std::vector<std::string>{"AC_1M"}}}});
 
-    auto& sink = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkC = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkD = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
 
-    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"analog_out", 0>(ps).template to<"in">(sink)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 0>(ps).template to<"in">(sinkA)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 1>(ps).template to<"in">(sinkB)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 2>(ps).template to<"in">(sinkC)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 3>(ps).template to<"in">(sinkD)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 6>(ps).template to<"in">(sinkG)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 7>(ps).template to<"in">(sinkH)));
 
     scheduler::Simple sched{std::move(flowGraph)};
     expect(sched.runAndWait().has_value());
 
-    expect(eq(sink._nSamplesProduced, totalSamples));
+    expect(eq(sinkA._nSamplesProduced, totalSamples));
 }
 
 template<typename T>
@@ -59,13 +76,30 @@ void testStreamingBasics() {
     constexpr float kSampleRate = 80000.f;
     constexpr auto  kDuration   = 2s;
 
-    auto& ps = flowGraph.emplaceBlock<PicoscopeT<T, AcquisitionMode::Streaming>>({{{"sample_rate", kSampleRate}, {"acquisition_mode", "Streaming"}, {"streaming_mode_poll_rate", 0.00001}, {"auto_arm", true}, {"channel_ids", std::vector<std::string>{"A"}}, {"channel_names", std::vector<std::string>{"Test signal"}}, {"channel_units", std::vector<std::string>{"Test unit"}}, {"channel_ranges", std::vector{5.}}, {"channel_couplings", std::vector<std::string>{"AC_1M"}}}});
+    auto& ps = flowGraph.emplaceBlock<PicoscopeT<T, AcquisitionMode::Streaming>>({{{"sample_rate", kSampleRate},                                                           //
+        {"acquisition_mode", "Streaming"}, {"streaming_mode_poll_rate", 0.00001f}, {"auto_arm", true}, {"channel_ids", std::vector<std::string>{"A"}},                     //
+        {"channel_names", std::vector<std::string>{"Test signal"}}, {"channel_units", std::vector<std::string>{"Test unit"}}, {"channel_ranges", std::vector<float>{5.f}}, //
+        {"channel_couplings", std::vector<std::string>{"AC_1M"}}}});
 
-    auto& tagMonitor = flowGraph.emplaceBlock<testing::TagMonitor<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}}});
-    auto& sink       = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& tagMonitor = flowGraph.emplaceBlock<testing::TagMonitor<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", true}}});
+    auto& sinkA      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkB      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkC      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkD      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkE      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkF      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkG      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkH      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
 
-    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"analog_out", 0>(ps).template to<"in">(tagMonitor)));
-    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out">(tagMonitor).template to<"in">(sink)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 0>(ps).template to<"in">(tagMonitor)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out">(tagMonitor).template to<"in">(sinkA)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 1>(ps).template to<"in">(sinkB)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 2>(ps).template to<"in">(sinkC)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 3>(ps).template to<"in">(sinkD)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 6>(ps).template to<"in">(sinkG)));
+    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 7>(ps).template to<"in">(sinkH)));
 
     // Explicitly start unit because it takes quite some time
     expect(nothrow([&ps] { ps.start(); }));
@@ -76,13 +110,14 @@ void testStreamingBasics() {
     std::this_thread::sleep_for(kDuration);
     expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value());
 
-    const auto measuredRate = static_cast<double>(sink._nSamplesProduced) / duration<double>(kDuration).count();
+    const auto measuredRate = static_cast<double>(sinkA._nSamplesProduced) / duration<double>(kDuration).count();
     fmt::println("Produced in worker: {}", ps.producedWorker());
     fmt::println("Configured rate: {}, Measured rate: {} ({:.2f}%), Duration: {} ms", kSampleRate, static_cast<std::size_t>(measuredRate), measuredRate / static_cast<double>(kSampleRate) * 100., duration_cast<milliseconds>(kDuration).count());
-    fmt::println("Total: {}", sink._nSamplesProduced);
+    fmt::println("Total samples: {}", sinkA._nSamplesProduced);
+    fmt::println("Total tags: {}", tagMonitor._tags.size());
 
-    expect(ge(sink._nSamplesProduced, 80000UZ));
-    expect(le(sink._nSamplesProduced, 170000UZ));
+    expect(ge(sinkA._nSamplesProduced, 80000UZ));
+    expect(le(sinkA._nSamplesProduced, 170000UZ));
     expect(ge(tagMonitor._tags.size(), 1UZ));
     if (tagMonitor._tags.size() == 1UZ) {
         const auto& tag = tagMonitor._tags[0];
@@ -129,41 +164,68 @@ const boost::ut::suite PicoscopeTests = [] {
     "rapid block multiple captures"_test = [] { testRapidBlockBasic<float>(3); };
 
     "rapid block 4 channels"_test = [] {
-        constexpr std::size_t kPreSamples   = 33;
-        constexpr std::size_t kPostSamples  = 1000;
-        constexpr std::size_t kNrCaptures   = 2;
-        constexpr auto        kTotalSamples = kNrCaptures * (kPreSamples + kPostSamples);
+        constexpr gr::Size_t kPreSamples   = 33;
+        constexpr gr::Size_t kPostSamples  = 1000;
+        constexpr gr::Size_t kNrCaptures   = 2;
+        constexpr gr::Size_t kTotalSamples = kNrCaptures * (kPreSamples + kPostSamples);
 
         Graph flowGraph;
-        auto& ps = flowGraph.emplaceBlock<PicoscopeT<float, AcquisitionMode::RapidBlock>>({{{"sample_rate", 10000.f}, {"pre_samples", kPreSamples}, {"post_samples", kPostSamples}, {"acquisition_mode", "RapidBlock"}, {"rapid_block_nr_captures", kNrCaptures}, {"auto_arm", true}, {"trigger_once", true}, {"channel_ids", std::vector<std::string>{"A", "B", "C", "D"}}, {"channel_ranges", std::vector{{5., 5., 5., 5.}}}, {"channel_couplings", std::vector<std::string>{"AC_1M", "AC_1M", "AC_1M", "AC_1M"}}}});
+        auto& ps = flowGraph.emplaceBlock<PicoscopeT<float, AcquisitionMode::RapidBlock>>({{{"sample_rate", 10000.f},                                   //
+            {"pre_samples", kPreSamples}, {"post_samples", kPostSamples}, {"acquisition_mode", "RapidBlock"}, {"rapid_block_nr_captures", kNrCaptures}, //
+            {"auto_arm", true}, {"trigger_once", true}, {"channel_ids", std::vector<std::string>{"A", "B", "C", "D"}},                                  //
+            {"channel_ranges", std::vector<float>{{5.f, 5.f, 5.f, 5.f}}}, {"channel_couplings", std::vector<std::string>{"AC_1M", "AC_1M", "AC_1M", "AC_1M"}}}});
 
-        auto& sink0 = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sink1 = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sink2 = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sink3 = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkC = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkD = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
 
-        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"analog_out", 0>(ps).to<"in">(sink0)));
-        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"analog_out", 1>(ps).to<"in">(sink1)));
-        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"analog_out", 2>(ps).to<"in">(sink2)));
-        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"analog_out", 3>(ps).to<"in">(sink3)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 0>(ps).template to<"in">(sinkA)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 1>(ps).template to<"in">(sinkB)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 2>(ps).template to<"in">(sinkC)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 3>(ps).template to<"in">(sinkD)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 6>(ps).template to<"in">(sinkG)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 7>(ps).template to<"in">(sinkH)));
 
         scheduler::Simple sched{std::move(flowGraph)};
         sched.runAndWait();
 
-        expect(eq(sink0._nSamplesProduced, kTotalSamples));
-        expect(eq(sink1._nSamplesProduced, kTotalSamples));
-        expect(eq(sink2._nSamplesProduced, kTotalSamples));
-        expect(eq(sink3._nSamplesProduced, kTotalSamples));
+        expect(eq(sinkA._nSamplesProduced, kTotalSamples));
+        expect(eq(sinkB._nSamplesProduced, kTotalSamples));
+        expect(eq(sinkC._nSamplesProduced, kTotalSamples));
+        expect(eq(sinkD._nSamplesProduced, kTotalSamples));
     };
 
     "rapid block continuous"_test = [] {
         using namespace std::chrono_literals;
         Graph flowGraph;
-        auto& ps = flowGraph.emplaceBlock<PicoscopeT<float, AcquisitionMode::RapidBlock>>({{{"sample_rate", 10000.f}, {"post_samples", std::size_t{1000}}, {"acquisition_mode", "RapidBlock"}, {"rapid_block_nr_captures", std::size_t{1}}, {"auto_arm", true}, {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector{5.}}, {"channel_couplings", std::vector<std::string>{"AC_1M"}}}});
+        auto& ps = flowGraph.emplaceBlock<PicoscopeT<float, AcquisitionMode::RapidBlock>>({{{"sample_rate", 10000.f},                               //
+            {"post_samples", gr::Size_t{1000}}, {"acquisition_mode", "RapidBlock"}, {"rapid_block_nr_captures", gr::Size_t{1}}, {"auto_arm", true}, //
+            {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}}, {"channel_couplings", std::vector<std::string>{"AC_1M"}}}});
 
-        auto& sink0 = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkC = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkD = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
 
-        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"analog_out", 0>(ps).to<"in">(sink0)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 0>(ps).to<"in">(sinkA)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 1>(ps).template to<"in">(sinkB)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 2>(ps).template to<"in">(sinkC)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 3>(ps).template to<"in">(sinkD)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 6>(ps).template to<"in">(sinkG)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 7>(ps).template to<"in">(sinkH)));
 
         scheduler::Simple<scheduler::ExecutionPolicy::multiThreaded> sched{std::move(flowGraph)};
         expect(sched.changeStateTo(lifecycle::State::INITIALISED).has_value());
@@ -171,8 +233,8 @@ const boost::ut::suite PicoscopeTests = [] {
         std::this_thread::sleep_for(3s);
         expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value());
 
-        expect(ge(sink0._nSamplesProduced, std::size_t{2000}));
-        expect(le(sink0._nSamplesProduced, std::size_t{10000}));
+        expect(ge(sinkA._nSamplesProduced, std::size_t{2000}));
+        expect(le(sinkA._nSamplesProduced, std::size_t{10000}));
     };
 };
 

--- a/blocklib/picoscope/test/qa_PicoscopePerformanceMonitor.cc
+++ b/blocklib/picoscope/test/qa_PicoscopePerformanceMonitor.cc
@@ -1,0 +1,90 @@
+#include <HelperBlocks.hpp>
+#include <Picoscope4000a.hpp>
+#include <Picoscope5000a.hpp>
+#include <boost/ut.hpp>
+#include <fmt/format.h>
+#include <gnuradio-4.0/Graph.hpp>
+#include <gnuradio-4.0/Scheduler.hpp>
+#include <gnuradio-4.0/testing/PerformanceMonitor.hpp>
+#include <gnuradio-4.0/testing/TagMonitors.hpp>
+#include <string>
+
+namespace {
+using namespace std::chrono_literals;
+template<typename Scheduler>
+auto createWatchdog(Scheduler& sched, std::chrono::seconds timeOut = 2s, std::chrono::milliseconds pollingPeriod = 40ms) {
+    auto externalInterventionNeeded = std::make_shared<std::atomic_bool>(false);
+
+    std::thread watchdogThread([&sched, externalInterventionNeeded, timeOut, pollingPeriod]() {
+        auto timeout = std::chrono::steady_clock::now() + timeOut;
+        while (std::chrono::steady_clock::now() < timeout) {
+            if (sched.state() == gr::lifecycle::State::STOPPED) {
+                return;
+            }
+            std::this_thread::sleep_for(pollingPeriod);
+        }
+        fmt::println("watchdog kicked in");
+        externalInterventionNeeded->store(true, std::memory_order_relaxed);
+        sched.requestStop();
+        fmt::println("requested scheduler to stop");
+    });
+
+    return std::make_pair(std::move(watchdogThread), externalInterventionNeeded);
+}
+} // namespace
+
+int main(int argc, char* argv[]) {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace gr::testing;
+    using namespace fair::helpers;
+    using namespace fair::picoscope;
+
+    int runTime = 60; // in seconds
+
+    if (argc >= 2) {
+        runTime = std::atoi(argv[1]);
+    }
+
+    using SampleType = float;
+
+    // Replace with your connected Picoscope device
+    using PicoscopeT = Picoscope4000a<SampleType, AcquisitionMode::Streaming>;
+
+    constexpr float kSampleRate = 20'000'000.f;
+
+    auto threadPool = std::make_shared<gr::thread_pool::BasicThreadPool>("custom pool", gr::thread_pool::CPU_BOUND, 2, 2);
+
+    Graph graph;
+
+    auto& ps = graph.emplaceBlock<PicoscopeT>({{{"sample_rate", kSampleRate},              //
+        {"acquisition_mode", "Streaming"}, {"auto_arm", true},                             //
+        {"channel_ids", std::vector<std::string>{"A", "B", "C", "D", "E", "F", "G", "H"}}, //
+        {"channel_ranges", std::vector<float>{5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f}}}});
+
+    auto& perfMonitorA = graph.emplaceBlock<PerformanceMonitor<SampleType>>({{"name", "Perf A"}});
+    auto& perfMonitorB = graph.emplaceBlock<PerformanceMonitor<SampleType>>({{"name", "Perf B"}});
+    auto& perfMonitorC = graph.emplaceBlock<PerformanceMonitor<SampleType>>({{"name", "Perf C"}});
+    auto& perfMonitorD = graph.emplaceBlock<PerformanceMonitor<SampleType>>({{"name", "Perf D"}});
+    auto& perfMonitorE = graph.emplaceBlock<PerformanceMonitor<SampleType>>({{"name", "Perf E"}});
+    auto& perfMonitorF = graph.emplaceBlock<PerformanceMonitor<SampleType>>({{"name", "Perf F"}});
+    auto& sinkG        = graph.emplaceBlock<testing::TagSink<SampleType, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkH        = graph.emplaceBlock<testing::TagSink<SampleType, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+
+    expect(eq(ConnectionResult::SUCCESS, graph.connect<"out", 0>(ps).template to<"in">(perfMonitorA)));
+    expect(eq(ConnectionResult::SUCCESS, graph.connect<"out", 1>(ps).template to<"in">(perfMonitorB)));
+    expect(eq(ConnectionResult::SUCCESS, graph.connect<"out", 2>(ps).template to<"in">(perfMonitorC)));
+    expect(eq(ConnectionResult::SUCCESS, graph.connect<"out", 3>(ps).template to<"in">(perfMonitorD)));
+    expect(eq(ConnectionResult::SUCCESS, graph.connect<"out", 4>(ps).template to<"in">(perfMonitorE)));
+    expect(eq(ConnectionResult::SUCCESS, graph.connect<"out", 5>(ps).template to<"in">(perfMonitorF)));
+    expect(eq(ConnectionResult::SUCCESS, graph.connect<"out", 6>(ps).template to<"in">(sinkG)));
+    expect(eq(ConnectionResult::SUCCESS, graph.connect<"out", 7>(ps).template to<"in">(sinkH)));
+
+    auto sched                                        = scheduler::Simple{std::move(graph), threadPool};
+    auto [watchdogThread, externalInterventionNeeded] = createWatchdog(sched, runTime > 0 ? std::chrono::seconds(runTime) : 20s);
+    expect(sched.runAndWait().has_value());
+
+    if (watchdogThread.joinable()) {
+        watchdogThread.join();
+    }
+}

--- a/blocklib/picoscope/test/qa_PicoscopeTiming.cc
+++ b/blocklib/picoscope/test/qa_PicoscopeTiming.cc
@@ -46,11 +46,11 @@ const boost::ut::suite PicoscopeTests = [] {
             {"channel_ids", std::vector<std::string>{"A", "B", "C"}},                   //
             {"channel_names", std::vector<std::string>{"Trigger", "IO2", "IO3"}},       //
             {"channel_units", std::vector<std::string>{"V", "V", "V"}},                 //
-            {"channel_ranges", std::vector{5.0, 5.0, 5.0}},                             //
-            {"channel_offsets", std::vector{0.0, 0.0, 0.0}},                            //
+            {"channel_ranges", std::vector<float>{5.f, 5.f, 5.f}},                      //
+            {"channel_offsets", std::vector<float>{0.f, 0.f, 0.f}},                     //
             {"channel_couplings", std::vector<std::string>{"DC_1M", "DC_1M", "DC_1M"}}, //
             {"trigger_source", "A"},                                                    //
-            {"trigger_threshold", 1.7},                                                 //
+            {"trigger_threshold", 1.7f},                                                //
             {"trigger_direction", "Rising"}                                             //
         }});
 
@@ -59,9 +59,9 @@ const boost::ut::suite PicoscopeTests = [] {
         auto& sinkC = flowGraph.emplaceBlock<gr::testing::TagSink<float, gr::testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", true}}});
 
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out">(timingSrc).template to<"timingIn">(ps)));
-        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"analog_out", 0>(ps).template to<"in">(sinkA)));
-        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"analog_out", 1>(ps).template to<"in">(sinkB)));
-        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"analog_out", 2>(ps).template to<"in">(sinkC)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 0>(ps).template to<"in">(sinkA)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 1>(ps).template to<"in">(sinkB)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 2>(ps).template to<"in">(sinkC)));
 
         // Explicitly start unit because it takes quite some time
         expect(nothrow([&ps] { ps.start(); }));


### PR DESCRIPTION
Update Picoscope block
* Bump GR4 version and fix `qa_Picoscope` test
* Serial number are correctly assigned
* Use floats for settings
* Add picoscope performance monitoring test
* Add `gain` setting
* Add `signal_qiantity` setting
* Publish not enough space in buffer tag
* Bug fixing

When setting `sample_rate` to 20M I got the following output for each channel:

```text
Performance at 2025-02-19T09:45:13.000045, #40 dT:1.0486361 s, rate:20.3 MS/s, memory_resident:250 Mb
Performance at 2025-02-19T09:45:13.000045, #40 dT:1.048635 s, rate:20.3 MS/s, memory_resident:250 Mb
Performance at 2025-02-19T09:45:13.000045, #40 dT:1.048638 s, rate:20.3 MS/s, memory_resident:250 Mb
Performance at 2025-02-19T09:45:13.000045, #40 dT:1.048636 s, rate:20.3 MS/s, memory_resident:250 Mb
Performance at 2025-02-19T09:45:13.000045, #40 dT:1.0486339 s, rate:20.3 MS/s, memory_resident:250 Mb
Performance at 2025-02-19T09:45:13.000045, #40 dT:1.0486319 s, rate:20.3 MS/s, memory_resident:250 Mb
```