### PR TITLE
Picoscope block updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set(ENABLE_TESTING OFF)
 FetchContent_Declare(
   gnuradio4
   GIT_REPOSITORY https://github.com/fair-acc/gnuradio4.git
-  GIT_TAG 18509c29f7a3860081a34593fa5d702ea78871ef # main as of 2025-02-27
+  GIT_TAG 7d0f9e6b6d979e5ce01d3eac26879565de8a16d0 # main as of 2025-03-11
 )
 
 FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set(ENABLE_TESTING OFF)
 FetchContent_Declare(
   gnuradio4
   GIT_REPOSITORY https://github.com/fair-acc/gnuradio4.git
-  GIT_TAG 3b58693a870ce32b24d43ed8a58ae2fcdd9a5ae6 # main as of 2025-02-19
+  GIT_TAG 18509c29f7a3860081a34593fa5d702ea78871ef # main as of 2025-02-27
 )
 
 FetchContent_Declare(

--- a/blocklib/picoscope/CMakeLists.txt
+++ b/blocklib/picoscope/CMakeLists.txt
@@ -1,4 +1,12 @@
 # TODO do not hardcode
+
+add_library(ps3000a SHARED IMPORTED GLOBAL)
+set_property(TARGET ps3000a PROPERTY IMPORTED_LOCATION
+                                     ${PICOSCOPE_PREFIX}/lib/libps3000a.so)
+target_link_libraries(ps3000a INTERFACE PkgConfig::zlib PkgConfig::libusb)
+target_include_directories(ps3000a
+                           INTERFACE ${PICOSCOPE_PREFIX}/include/libps3000a)
+
 add_library(ps4000a SHARED IMPORTED GLOBAL)
 set_property(TARGET ps4000a PROPERTY IMPORTED_LOCATION
                                      ${PICOSCOPE_PREFIX}/lib/libps4000a.so)
@@ -23,12 +31,20 @@ target_include_directories(
                            $<INSTALL_INTERFACE:include/>)
 
 target_link_libraries(
-  fair-picoscope INTERFACE ps4000a ps5000a gr-digitizers-options gnuradio-core
-                           gnuradio-algorithm fmt)
+  fair-picoscope
+  INTERFACE ps3000a
+            ps4000a
+            ps5000a
+            gr-digitizers-options
+            gnuradio-core
+            gnuradio-algorithm
+            fmt)
 set_target_properties(
   gr-digitizers
-  PROPERTIES PUBLIC_HEADER
-             "Picoscope.hpp;Picoscope4000a.hpp;StatusMessages.hpp")
+  PROPERTIES
+    PUBLIC_HEADER
+    "Picoscope.hpp;Picoscope3000a.hpp;Picoscope4000a.hpp;Picoscope5000a.hpp;StatusMessages.hpp"
+)
 
 if(ENABLE_GR_DIGITIZERS_TESTING)
   add_subdirectory(test)

--- a/blocklib/picoscope/CMakeLists.txt
+++ b/blocklib/picoscope/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(
                            $<INSTALL_INTERFACE:include/>)
 
 target_link_libraries(
-  fair-picoscope INTERFACE ps4000a ps5000a gr-digitizers-options gnuradio-core
+  fair-picoscope INTERFACE ps4000a ps5000a gr-digitizers-options gnuradio-core gnuradio-algorithm
                            fmt)
 set_target_properties(
   gr-digitizers

--- a/blocklib/picoscope/CMakeLists.txt
+++ b/blocklib/picoscope/CMakeLists.txt
@@ -23,8 +23,8 @@ target_include_directories(
                            $<INSTALL_INTERFACE:include/>)
 
 target_link_libraries(
-  fair-picoscope INTERFACE ps4000a ps5000a gr-digitizers-options gnuradio-core gnuradio-algorithm
-                           fmt)
+  fair-picoscope INTERFACE ps4000a ps5000a gr-digitizers-options gnuradio-core
+                           gnuradio-algorithm fmt)
 set_target_properties(
   gr-digitizers
   PROPERTIES PUBLIC_HEADER

--- a/blocklib/picoscope/Picoscope.hpp
+++ b/blocklib/picoscope/Picoscope.hpp
@@ -5,6 +5,7 @@
 
 #include <PicoConnectProbes.h>
 #include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/algorithm/dataset/DataSetUtils.hpp>
 
 #include <fmt/format.h>
 
@@ -35,7 +36,7 @@ enum class TimeUnits { FS, PS, NS, US, MS, S };
 
 struct GetValuesResult {
     Error       error;
-    std::size_t samples;
+    std::size_t nSamples;
     int16_t     overflow;
 };
 
@@ -87,8 +88,17 @@ namespace detail {
 
 constexpr std::size_t kDriverBufferSize = 65536;
 
-struct ChannelSetting {
+[[nodiscard]] inline bool isDigitalTrigger(std::string_view source) { return !source.empty() && source == "DI"; }
+[[nodiscard]] inline bool isAnalogTrigger(std::string_view source) { return !source.empty() && source != "DI"; }
+
+struct Channel {
+    std::string          id;
+    std::vector<int16_t> driverBuffer;
+    bool                 signalInfoTagPublished = false;
+
+    // settings
     std::string name;
+    float       sampleRate;
     std::string unit         = "V";
     std::string quantity     = "Voltage";
     float       range        = 2.f;
@@ -96,152 +106,25 @@ struct ChannelSetting {
     float       scale        = 1.f;
     float       offset       = 0.f;
     Coupling    coupling     = Coupling::AC_1M;
-};
 
-using ChannelMap = std::map<std::string, ChannelSetting, std::less<>>;
-
-struct TriggerSetting {
-    static constexpr std::string_view kTriggerDigitalSource = "DI"; // DI is as well-used as "AUX" for p6000 scopes
-
-    bool isEnabled() const { return !source.empty(); }
-
-    bool isDigital() const { return isEnabled() && source == kTriggerDigitalSource; }
-
-    bool isAnalog() const { return isEnabled() && source != kTriggerDigitalSource; }
-
-    std::string      source;
-    float            threshold  = 0; // AI only
-    TriggerDirection direction  = TriggerDirection::Rising;
-    int              pin_number = 0; // DI only
-};
-
-template<typename T>
-struct Channel {
-    std::string          id;
-    ChannelSetting       settings;
-    std::vector<int16_t> driver_buffer;
-    bool                 signal_info_written = false;
-
-    gr::property_map toTagMap() const {
-        using namespace gr;
-        static const auto kSignalName     = std::string(tag::SIGNAL_NAME.shortKey());
-        static const auto kSignalQuantity = std::string(tag::SIGNAL_QUANTITY.shortKey());
-        static const auto kSignalUnit     = std::string(tag::SIGNAL_UNIT.shortKey());
-        static const auto kSignalMin      = std::string(tag::SIGNAL_MIN.shortKey());
-        static const auto kSignalMax      = std::string(tag::SIGNAL_MAX.shortKey());
-        return {{kSignalName, settings.name}, {kSignalQuantity, settings.quantity}, {kSignalUnit, settings.unit}, {kSignalMin, settings.offset}, {kSignalMax, settings.offset + settings.range}};
+    [[nodiscard]] gr::property_map toTagMap() const {
+        return {{std::string(gr::tag::SIGNAL_NAME.shortKey()), name},     //
+            {std::string(gr::tag::SAMPLE_RATE.shortKey()), sampleRate},   //
+            {std::string(gr::tag::SIGNAL_QUANTITY.shortKey()), quantity}, //
+            {std::string(gr::tag::SIGNAL_UNIT.shortKey()), unit},         //
+            {std::string(gr::tag::SIGNAL_MIN.shortKey()), offset},        //
+            {std::string(gr::tag::SIGNAL_MAX.shortKey()), offset + range}};
     }
 };
 
-struct Settings {
-    std::string     serial_number;
-    float           sample_rate              = 10000.f;
-    AcquisitionMode acquisition_mode         = AcquisitionMode::Streaming;
-    std::size_t     pre_samples              = 1000;
-    std::size_t     post_samples             = 9000;
-    std::size_t     rapid_block_nr_captures  = 1;
-    bool            trigger_once             = false;
-    float           streaming_mode_poll_rate = 0.001;
-    bool            auto_arm                 = true;
-    ChannelMap      enabled_channels;
-    TriggerSetting  trigger;
-};
-
-template<typename T>
-struct State {
-    std::vector<Channel<T>> channels;
-    std::atomic<bool>       data_finished      = false;
-    bool                    initialized        = false;
-    bool                    configured         = false;
-    bool                    closed             = false;
-    bool                    armed              = false;
-    bool                    started            = false; // TODO transitional until nodes have state handling
-    int8_t                  trigger_state      = 0;
-    int16_t                 handle             = -1; ///< picoscope handle
-    int16_t                 overflow           = 0;  ///< status returned from getValues
-    int16_t                 max_value          = 0;  ///< maximum ADC count used for ADC conversion
-    float                   actual_sample_rate = 0;
-    std::size_t             produced_worker    = 0; // poller/callback thread
-};
-
-inline AcquisitionMode parseAcquisitionMode(std::string_view s) {
-    using enum AcquisitionMode;
-    if (s == "RapidBlock") {
-        return RapidBlock;
+template<typename TEnum>
+constexpr TEnum convertToEnum(std::string_view strEnum) {
+    auto enumType = magic_enum::enum_cast<TEnum>(strEnum, magic_enum::case_insensitive);
+    if (!enumType.has_value()) {
+        throw std::invalid_argument(fmt::format("Unknown value. Cannot convert string '{}' to enum '{}'", strEnum, gr::meta::type_name<TEnum>()));
     }
-    if (s == "Streaming") {
-        return Streaming;
-    }
-    throw std::invalid_argument(fmt::format("Unknown acquisition mode '{}'", s));
+    return enumType.value();
 }
-
-inline Coupling parseCoupling(std::string_view s) {
-    using enum Coupling;
-    if (s == "DC_1M") {
-        return DC_1M;
-    }
-    if (s == "AC_1M") {
-        return AC_1M;
-    }
-    if (s == "DC_50R") {
-        return DC_50R;
-    }
-    throw std::invalid_argument(fmt::format("Unknown coupling type '{}'", s));
-}
-
-inline TriggerDirection parseTriggerDirection(std::string_view s) {
-    using enum TriggerDirection;
-    if (s == "Rising") {
-        return Rising;
-    }
-    if (s == "Falling") {
-        return Falling;
-    }
-    if (s == "Low") {
-        return Low;
-    }
-    if (s == "High") {
-        return High;
-    }
-    throw std::invalid_argument(fmt::format("Unknown trigger direction '{}'", s));
-}
-
-inline ChannelMap channelSettings(std::span<std::string> ids, std::span<std::string> names, std::span<std::string> units, std::span<std::string> quantities, std::span<float> ranges, std::span<float> analogOffsets, std::span<float> scales, std::span<float> offsets, std::span<std::string> couplings) {
-    ChannelMap r;
-    for (std::size_t i = 0; i < ids.size(); ++i) {
-        ChannelSetting channel;
-        if (i < names.size()) {
-            channel.name = names[i];
-        } else {
-            channel.name = fmt::format("signal {} ({})", i, ids[i]);
-        }
-        if (i < units.size()) {
-            channel.unit = std::string(units[i]);
-        }
-        if (i < quantities.size()) {
-            channel.quantity = std::string(quantities[i]);
-        }
-        if (i < ranges.size()) {
-            channel.range = ranges[i];
-        }
-        if (i < analogOffsets.size()) {
-            channel.analogOffset = analogOffsets[i];
-        }
-        if (i < scales.size()) {
-            channel.scale = scales[i];
-        }
-        if (i < offsets.size()) {
-            channel.offset = offsets[i];
-        }
-        if (i < couplings.size()) {
-            channel.coupling = parseCoupling(couplings[i]);
-        }
-
-        r[std::string(ids[i])] = channel;
-    }
-    return r;
-}
-
 } // namespace detail
 
 // optional shortening
@@ -251,51 +134,50 @@ using A = gr::Annotated<T, description, Arguments...>;
 using gr::Visible;
 
 /**
- * We only allow a small set of types to be used as the output type for the Picoscope Block:
+ * We allow only a small set of sample types (SampleType) to be used as the output type for the Picoscope block:
+ * - `std::int16_t`: Outputs raw values as-is, without any scaling.
+ * - `float`: Outputs the physically gain-scaled values of the measurements.
+ * - `gr::UncertainValue<float>`: Similar to `float`, but also includes an estimated measurement error as an additional component.
  *
- * - std::int16_t
- *   This outputs the raw values as-is without any scaling.
- *
- * - float
- *   The physical gain-scaled output of the measured values
- *
- * - gr::UncertainValue<float>
- *   Same as "float", except it also contains the estimated measurement error as an additional component.
- **/
+ * The output type also determines the acquisition mode:
+ * - For `DataSet<SampleType>`, the acquisition mode is **RapidBlock**.
+ * - For `SampleType`, the acquisition mode is **Streaming**.
+ */
+
 template<typename T>
-concept PicoscopeOutput = std::disjunction_v<std::is_same<T, std::int16_t>, std::is_same<T, float>, std::is_same<T, gr::UncertainValue<float>>>;
+concept PicoscopeOutput = std::disjunction_v<std::is_same<T, std::int16_t>, std::is_same<T, float>, std::is_same<T, gr::UncertainValue<float>>, //
+    std::is_same<T, gr::DataSet<std::int16_t>>, std::is_same<T, gr::DataSet<float>>, std::is_same<T, gr::DataSet<gr::UncertainValue<float>>>>;
 
 // helper struct to conditionally enable BlockingIO at compile time
 template<typename TPSImpl, bool>
 struct PicoscopeBlockingHelper;
 
 template<typename TPSImpl>
-struct PicoscopeBlockingHelper<TPSImpl, false> {
+struct PicoscopeBlockingHelper<TPSImpl, false> { // Streaming mode
     using type = gr::Block<TPSImpl, gr::SupportedTypes<int16_t, float, gr::UncertainValue<float>>>;
 };
 
 template<typename TPSImpl>
-struct PicoscopeBlockingHelper<TPSImpl, true> {
-    using type = gr::Block<TPSImpl, gr::SupportedTypes<int16_t, float, gr::UncertainValue<float>>, gr::BlockingIO<false>>;
+struct PicoscopeBlockingHelper<TPSImpl, true> { // RapidBlock mode
+    using type = gr::Block<TPSImpl, gr::SupportedTypes<gr::DataSet<int16_t>, gr::DataSet<float>, gr::DataSet<gr::UncertainValue<float>>>, gr::BlockingIO<false>>;
 };
 
-template<PicoscopeOutput T, AcquisitionMode acquisitionMode, typename TPSImpl>
-class Picoscope : public PicoscopeBlockingHelper<TPSImpl, acquisitionMode == AcquisitionMode::RapidBlock>::type {
+template<PicoscopeOutput T, typename TPSImpl>
+class Picoscope : public PicoscopeBlockingHelper<TPSImpl, gr::DataSetLike<T>>::type {
 public:
-    using super_t = typename PicoscopeBlockingHelper<TPSImpl, acquisitionMode == AcquisitionMode::RapidBlock>::type;
+    using super_t                                    = typename PicoscopeBlockingHelper<TPSImpl, gr::DataSetLike<T>>::type;
+    static constexpr AcquisitionMode acquisitionMode = gr::DataSetLike<T> ? AcquisitionMode::RapidBlock : AcquisitionMode::Streaming;
 
     Picoscope(gr::property_map props) : super_t(std::move(props)) {}
 
-    A<std::string, "serial number">  serial_number;
-    A<float, "sample rate", Visible> sample_rate = 10000.f;
-    // TODO any way to get custom enums into pmtv??
-    A<std::string, "acquisition mode", Visible>                        acquisition_mode         = std::string("Streaming");
-    A<gr::Size_t, "pre-samples">                                       pre_samples              = 1000;
-    A<gr::Size_t, "post-samples">                                      post_samples             = 9000;
-    A<gr::Size_t, "no. captures (rapid block mode)">                   rapid_block_nr_captures  = 1;
-    A<bool, "trigger once (rapid block mode)">                         trigger_once             = false;
-    A<float, "poll rate (streaming mode)">                             streaming_mode_poll_rate = 0.001;
-    A<bool, "auto-arm">                                                auto_arm                 = true;
+    A<std::string, "serial number">                                    serial_number;
+    A<float, "sample rate", Visible>                                   sample_rate              = 10000.f;
+    A<gr::Size_t, "pre-samples">                                       pre_samples              = 1000;  // RapidBlock mode only
+    A<gr::Size_t, "post-samples">                                      post_samples             = 1000;  // RapidBlock mode only
+    A<gr::Size_t, "no. captures (rapid block mode)">                   n_captures               = 1;     // RapidBlock mode only
+    A<bool, "trigger once (rapid block mode)">                         trigger_once             = false; // RapidBlock mode only
+    A<float, "poll rate (streaming mode)">                             streaming_mode_poll_rate = 0.001; // TODO, not used for the moment
+    A<bool, "do arm at start?">                                        auto_arm                 = true;
     A<std::vector<std::string>, "IDs of enabled channels">             channel_ids;
     A<std::vector<float>, "Voltage range of enabled channels">         channel_ranges;         // PS channel setting
     A<std::vector<float>, "Voltage offset of enabled channels">        channel_analog_offsets; // PS channel setting
@@ -303,83 +185,121 @@ public:
     A<std::vector<std::string>, "Signal names of enabled channels">    signal_names;
     A<std::vector<std::string>, "Signal units of enabled channels">    signal_units;
     A<std::vector<std::string>, "Signal quantity of enabled channels"> signal_quantities;
-    A<std::vector<float>, "Signal scales of the enabled channels">     signal_scales;  // only for floats
-    A<std::vector<float>, "Signal offset of the enabled channels">     signal_offsets; // only for floats
+    A<std::vector<float>, "Signal scales of the enabled channels">     signal_scales;  // only for floats and UncertainValues
+    A<std::vector<float>, "Signal offset of the enabled channels">     signal_offsets; // only for floats and UncertainValues
     A<std::string, "trigger channel/port ID">                          trigger_source;
     A<float, "trigger threshold, analog only">                         trigger_threshold = 0.f;
     A<std::string, "trigger direction">                                trigger_direction = std::string("Rising");
     A<int, "trigger pin, digital only">                                trigger_pin       = 0;
 
-    A<std::size_t, "time without any tags that triggers a systemtime event"> systemtime_interval = 1000;
-
-    detail::State<T> ps_state;
-    detail::Settings ps_settings;
-
     gr::PortIn<std::uint8_t, gr::Async> timingIn;
 
-    GR_MAKE_REFLECTABLE(Picoscope, timingIn, serial_number, sample_rate, pre_samples, post_samples, acquisition_mode, rapid_block_nr_captures, streaming_mode_poll_rate,              //
+    int16_t     _handle            = -1; // identifier for the scope device
+    float       _actualSampleRate  = 0;
+    std::size_t _nSamplesPublished = 0; // for debugging purposes
+
+    GR_MAKE_REFLECTABLE(Picoscope, timingIn, serial_number, sample_rate, pre_samples, post_samples, n_captures, streaming_mode_poll_rate,                                             //
         auto_arm, trigger_once, channel_ids, signal_names, signal_units, signal_quantities, channel_ranges, channel_analog_offsets, signal_scales, signal_offsets, channel_couplings, //
         trigger_source, trigger_threshold, trigger_direction, trigger_pin);
 
 private:
-    std::mutex                   g_init_mutex;
-    std::atomic<std::size_t>     streamingSamples = 0UZ;
-    std::atomic<std::size_t>     streamingOffset  = 0UZ;
-    std::queue<gr::property_map> timingMessages;
+    std::atomic<std::size_t>     _streamingSamples = 0UZ;
+    std::atomic<std::size_t>     _streamingOffset  = 0UZ;
+    std::queue<gr::property_map> _timingMessages;
+    std::atomic<bool>            _canWorkArm = false; // for RapidBlock mode if arm() can be done again in work() function
+    std::vector<detail::Channel> _channels;
+    int8_t                       _triggerState = 0;
+    int16_t                      _maxValue     = 0; // maximum ADC count used for ADC conversion
 
     std::chrono::high_resolution_clock::time_point nextSystemtime = std::chrono::high_resolution_clock::now();
 
 public:
     ~Picoscope() { stop(); }
 
-    void settingsChanged(const gr::property_map& /*old_settings*/, const gr::property_map& /*new_settings*/) {
-        const auto wasStarted = ps_state.started;
-        if (wasStarted) {
+    template<typename = void>
+    gr::work::Result work(std::size_t requestedWork = std::numeric_limits<std::size_t>::max()) noexcept {
+        if constexpr (acquisitionMode == AcquisitionMode::Streaming) {
+            return this->workInternal(requestedWork);
+        } else { // AcquisitionMode::RapidBlock
+
+            const bool blockIsActive = gr::lifecycle::isActive(this->state());
+            if (!blockIsActive) {
+                // fmt::println("work ioLastWorkStatus DONE");
+                this->ioLastWorkStatus.exchange(gr::work::Status::DONE, std::memory_order_relaxed);
+            } else {
+                // arm only in active state
+                bool expected = true;
+                if (_canWorkArm.compare_exchange_strong(expected, false, std::memory_order_acq_rel)) {
+                    arm();
+                }
+            }
+            const auto& [accumulatedRequestedWork, performedWork] = this->ioWorkDone.getAndReset();
+            return {accumulatedRequestedWork, performedWork, this->ioLastWorkStatus.load()};
+        }
+    }
+
+    [[nodiscard]] bool isRunning() { return _handle > 0; }
+
+    void settingsChanged(const gr::property_map& /*oldSettings*/, const gr::property_map& /*newSettings*/) {
+        const bool needsStartStop = isRunning();
+        if (needsStartStop) {
             stop();
         }
-        try {
-            auto s = detail::Settings{.serial_number = serial_number, //
-                .sample_rate                         = sample_rate,
-                .acquisition_mode                    = detail::parseAcquisitionMode(acquisition_mode),
-                .pre_samples                         = pre_samples,
-                .post_samples                        = post_samples,
-                .rapid_block_nr_captures             = rapid_block_nr_captures,
-                .trigger_once                        = trigger_once,
-                .streaming_mode_poll_rate            = streaming_mode_poll_rate,
-                .auto_arm                            = auto_arm,
-                .enabled_channels                    = detail::channelSettings(channel_ids.value, signal_names.value, signal_units.value, signal_quantities.value, channel_ranges.value, channel_analog_offsets.value, signal_scales.value, signal_offsets.value, channel_couplings.value),
-                .trigger                             = detail::TriggerSetting{.source = trigger_source, .threshold = trigger_threshold, .direction = detail::parseTriggerDirection(trigger_direction), .pin_number = trigger_pin}};
-            std::swap(ps_settings, s);
 
-            ps_state.channels.clear();
-            ps_state.channels.reserve(ps_settings.enabled_channels.size());
-            for (const auto& [id, settings] : ps_settings.enabled_channels) {
-                ps_state.channels.emplace_back(detail::Channel<T>{.id = id, .settings = settings, .driver_buffer = std::vector<int16_t>(detail::kDriverBufferSize)});
+        _channels.clear();
+        _channels.resize(channel_ids.value.size());
+
+        for (std::size_t i = 0; i < channel_ids.value.size(); ++i) {
+            detail::Channel& ch = _channels[i];
+            ch.id               = channel_ids.value[i];
+            ch.sampleRate       = sample_rate;
+
+            if (i < signal_names.value.size()) {
+                ch.name = signal_names.value[i];
+            } else {
+                ch.name = fmt::format("signal {} ({})", i, channel_ids.value[i]);
             }
-        } catch (const std::exception& e) {
-            // TODO add errors properly
-            fmt::println(std::cerr, "Could not apply settings: {}", e.what());
+            if (i < signal_units.value.size()) {
+                ch.unit = std::string(signal_units.value[i]);
+            }
+            if (i < signal_quantities.value.size()) {
+                ch.quantity = std::string(signal_quantities.value[i]);
+            }
+            if (i < channel_ranges.value.size()) {
+                ch.range = channel_ranges.value[i];
+            }
+            if (i < channel_analog_offsets.value.size()) {
+                ch.analogOffset = channel_analog_offsets.value[i];
+            }
+            if (i < signal_scales.value.size()) {
+                ch.scale = signal_scales.value[i];
+            }
+            if (i < signal_offsets.value.size()) {
+                ch.offset = signal_offsets.value[i];
+            }
+            if (i < channel_couplings.value.size()) {
+                ch.coupling = detail::convertToEnum<Coupling>(channel_couplings.value[i]);
+            }
+
+            ch.driverBuffer.resize(detail::kDriverBufferSize);
         }
-        if (wasStarted) {
+        if (needsStartStop) {
             start();
         }
     }
 
-    // TODO only for debugging, maybe remove
-    std::size_t producedWorker() const { return ps_state.produced_worker; }
-
     void start() noexcept {
-        if (ps_state.started) {
+        if (isRunning()) {
             return;
         }
+        _canWorkArm.store(false);
 
         try {
             initialize();
-            configure();
-            if (ps_settings.auto_arm) {
+            if (auto_arm) {
                 arm();
             }
-            ps_state.started = true;
+            serial_number = serialNumber();
             fmt::println("Picoscope serial number: {}", serial_number);
         } catch (const std::exception& e) {
             fmt::println(std::cerr, "{}", e.what());
@@ -387,211 +307,142 @@ public:
     }
 
     void stop() noexcept {
-        if (!ps_state.started) {
+        if (!isRunning()) {
             return;
         }
-
-        ps_state.started = false;
-
-        if (!ps_state.initialized) {
-            return;
-        }
-
+        _canWorkArm.store(false);
         disarm();
         close();
     }
 
-    std::string driverVersion() const { return self().driver_driverVersion(); }
+    void disarm() noexcept {
+        if (const auto status = self().driverStop(_handle); status != PICO_OK) {
+            this->emitErrorMessage("Picoscope::disarm()", gr::Error(detail::getErrorMessage(status)));
+        }
+    }
 
-    std::string hardwareVersion() const { return self().driver_hardwareVersion(); }
-
-    std::string serialNumber() const { return self().driver_serialNumber(); }
+    void close() noexcept {
+        if (!isRunning()) {
+            return;
+        }
+        if (const auto status = self().closeUnit(_handle); status != PICO_OK) {
+            this->emitErrorMessage("Picoscope::close()", gr::Error(detail::getErrorMessage(status)));
+        } else {
+            _handle = -1;
+        }
+    }
 
     void initialize() {
-        if (ps_state.initialized) {
+
+        if (isRunning()) { // already initialised
             return;
         }
 
-        if (const auto ec = self().driver_initialize()) {
-            throw std::runtime_error(fmt::format("Initialization failed: {}", ec.message()));
+        // power supply mode
+        if (const auto status = self().openUnit(serial_number); status == PICO_POWER_SUPPLY_NOT_CONNECTED || status == PICO_USB3_0_DEVICE_NON_USB3_0_PORT) {
+            if (const auto statusPower = self().changePowerSource(_handle, status); statusPower != PICO_OK) {
+                this->emitErrorMessage("Picoscope::initialize() changePowerSource", gr::Error(detail::getErrorMessage(statusPower)));
+            }
         }
 
-        ps_state.initialized = true;
-
-        serial_number = serialNumber();
-    }
-
-    void close() {
-        self().driver_close();
-        ps_state.closed      = true;
-        ps_state.initialized = false;
-        ps_state.configured  = false;
-    }
-
-    void configure() {
-        if (!ps_state.initialized) {
-            throw std::runtime_error("Cannot configure without initialization");
+        // maximum value is used for conversion to volts
+        if (const auto status = self().maximumValue(_handle, &(_maxValue)); status != PICO_OK) {
+            self().closeUnit(_handle);
+            this->emitErrorMessage("Picoscope::initialize() maximumValue", gr::Error(detail::getErrorMessage(status)));
         }
 
-        if (ps_state.armed) {
-            throw std::runtime_error("Cannot configure armed device");
+        // configure memory segments and number of capture fo RapidBlock mode
+        if constexpr (acquisitionMode == AcquisitionMode::RapidBlock) {
+            int32_t maxSamples;
+            if (const auto status = self().memorySegments(_handle, static_cast<uint32_t>(n_captures), &maxSamples); status != PICO_OK) {
+                this->emitErrorMessage("Picoscope::initialize() MemorySegments", gr::Error(detail::getErrorMessage(status)));
+            }
+
+            if (const auto status = self().setNoOfCaptures(_handle, static_cast<uint32_t>(n_captures)); status != PICO_OK) {
+                this->emitErrorMessage("Picoscope::initialize() SetNoOfCaptures", gr::Error(detail::getErrorMessage(status)));
+            }
         }
 
-        if (const auto ec = self().driver_configure()) {
-            throw std::runtime_error(fmt::format("Configuration failed: {}", ec.message()));
+        // configure analog channels
+        for (const auto& channel : _channels) {
+            const auto channelEnum = self().convertToChannel(channel.id);
+            assert(channelEnum);
+            const auto coupling = self().convertToCoupling(channel.coupling);
+            const auto range    = self().convertToRange(channel.range);
+
+            const auto status = self().setChannel(_handle, *channelEnum, true, coupling, static_cast<TPSImpl::ChannelRangeType>(range), static_cast<float>(channel.analogOffset));
+            if (status != PICO_OK) {
+                this->emitErrorMessage("Picoscope::initialize() SetChannel", gr::Error(detail::getErrorMessage(status)));
+            }
         }
 
-        ps_state.configured = true;
+        // apply trigger configuration
+        if (detail::isAnalogTrigger(trigger_source) && acquisitionMode == AcquisitionMode::RapidBlock) {
+            const auto channelEnum = self().convertToChannel(trigger_source);
+            assert(channelEnum != std::nullopt);
+            const auto    direction    = self().convertToThresholdDirection(detail::convertToEnum<TriggerDirection>(trigger_direction));
+            const int16_t thresholdADC = convertVoltageToADCCount(trigger_threshold);
+
+            const auto status = self().setSimpleTrigger(_handle, true, *channelEnum, thresholdADC, direction, 0 /* delay */, 0 /* auto trigger */);
+            if (status != PICO_OK) {
+                this->emitErrorMessage("Picoscope::initialize() setSimpleTrigger", gr::Error(detail::getErrorMessage(status)));
+            }
+        } else { // disable triggers
+            for (int i = 0; i < self().maxChannel(); i++) {
+                typename TPSImpl::ConditionType cond;
+                cond.source       = static_cast<TPSImpl::ChannelType>(i);
+                cond.condition    = self().conditionDontCare();
+                const auto status = self().setTriggerChannelConditions(_handle, &cond, 1, self().conditionsInfoClear());
+                if (status != PICO_OK) {
+                    this->emitErrorMessage("Picoscope::initialize() SetTriggerChannelConditions", gr::Error(detail::getErrorMessage(status)));
+                }
+            }
+        }
     }
 
     void arm() {
-        if (ps_state.armed) {
-            return;
-        }
+        if constexpr (acquisitionMode == AcquisitionMode::RapidBlock) {
+            const auto timebaseRes = self().convertSampleRateToTimebase(_handle, sample_rate);
+            _actualSampleRate      = timebaseRes.actualFreq;
 
-        if (const auto ec = self().driver_arm()) {
-            throw std::runtime_error(fmt::format("Arming failed: {}", ec.message()));
-        }
+            static auto    redirector = [](int16_t, PICO_STATUS status, void* vobj) { static_cast<decltype(this)>(vobj)->rapidBlockCallback({status}); };
+            int32_t        timeIndisposedMs;
+            const uint32_t segmentIndex = 0; // only one segment for streaming mode
 
-        ps_state.armed = true;
-    }
+            const auto status = self().runBlock(_handle, static_cast<int32_t>(pre_samples), static_cast<int32_t>(post_samples), timebaseRes.timebase, &timeIndisposedMs, segmentIndex, static_cast<TPSImpl::BlockReadyType>(redirector), this);
 
-    void disarm() noexcept {
-        if (!ps_state.armed) {
-            return;
-        }
-
-        if (const auto ec = self().driver_disarm()) {
-            fmt::println(std::cerr, "disarm failed: {}", ec.message());
-        }
-
-        ps_state.armed = false;
-    }
-
-    template<gr::OutputSpanLike TOutSpan>
-    void processDriverData(std::size_t nrSamples, std::size_t offset, std::span<TOutSpan>& outputs, gr::InputSpanLike auto& timingInSpan) {
-        std::vector<std::size_t> triggerOffsets;
-        std::size_t              availableOutputs = std::numeric_limits<std::size_t>::max();
-        for (std::size_t channelIdx = 0; channelIdx < ps_state.channels.size(); ++channelIdx) {
-            availableOutputs = std::min(availableOutputs, outputs[channelIdx].size());
-        }
-
-        bool              publishNotEnoughSpaceInBuffer = false;
-        const std::size_t availableSamples              = std::min(availableOutputs, nrSamples);
-        if (availableSamples < nrSamples) {
-            publishNotEnoughSpaceInBuffer = true;
-            fmt::println(std::cerr, "Picoscope::processDriverData: {} samples will be lost due to insufficient space in output buffers (require {}, available {})", nrSamples - availableSamples, nrSamples, availableOutputs);
-        }
-
-        for (std::size_t channelIdx = 0; channelIdx < ps_state.channels.size(); ++channelIdx) {
-            auto& channel = ps_state.channels[channelIdx];
-            auto& output  = outputs[channelIdx];
-
-            const auto driverData = std::span(channel.driver_buffer).subspan(offset, availableSamples);
-
-            if constexpr (std::is_same_v<T, int16_t>) {
-                std::copy(driverData.begin(), driverData.end(), output.begin());
-            } else {
-                const float voltageMultiplier = channel.settings.range / static_cast<float>(ps_state.max_value);
-                // TODO use SIMD
-                for (std::size_t i = 0; i < availableSamples; ++i) {
-                    if constexpr (std::is_same_v<T, float>) {
-                        output[i] = channel.settings.offset + channel.settings.scale * voltageMultiplier * driverData[i];
-                    } else if constexpr (std::is_same_v<T, gr::UncertainValue<float>>) {
-                        output[i] = gr::UncertainValue(channel.settings.offset + channel.settings.scale * voltageMultiplier * driverData[i], self().uncertainty());
-                    }
-                }
+            if (status != PICO_OK) {
+                this->emitErrorMessage("Picoscope::arm() RunBlock", gr::Error(detail::getErrorMessage(status)));
             }
+        } else {
+            using fair::picoscope::detail::kDriverBufferSize;
+            self().setBuffers(kDriverBufferSize, 0);
 
-            if (channel.id == ps_settings.trigger.source) {
-                triggerOffsets = findAnalogTriggers(channel, std::span(output).subspan(0, availableSamples));
+            TimeInterval timeInterval = convertSampleRateToTimeInterval(sample_rate);
+
+            const auto status = self().runStreaming(        //
+                _handle,                                    // identifier for the scope device
+                &timeInterval.interval,                     // in: desired interval, out: actual interval
+                self().convertTimeUnits(timeInterval.unit), // time unit of interval
+                0,                                          // pre-trigger-samples (unused)
+                static_cast<uint32_t>(kDriverBufferSize),   // post-trigger-samples
+                false,                                      // autoStop
+                1,                                          // downsampling ratio
+                self().ratioNone(),                         // downsampling ratio mode
+                static_cast<uint32_t>(kDriverBufferSize));  // the size of the overview buffers
+
+            if (status != PICO_OK) {
+                this->emitErrorMessage("Picoscope::arm() RunStreaming", gr::Error(detail::getErrorMessage(status)));
             }
+            _actualSampleRate = convertTimeIntervalToSampleRate(timeInterval);
         }
-
-        const auto nowStamp = std::chrono::high_resolution_clock::now();
-        const auto now      = std::chrono::duration_cast<std::chrono::nanoseconds>(nowStamp.time_since_epoch());
-
-        std::size_t consumeTags = 0UZ;
-        for (const auto& tag : timingInSpan.tags()) {
-            if (!tag.second.contains(gr::tag::CONTEXT.shortKey())) { // only consider timing tags
-                consumeTags++;
-                continue;
-            }
-            // TODO: Allow to match multiple events to a single trigger here and allow to timeout on events where the trigger pulse was somehow lost
-            if (triggerOffsets.size() <= timingMessages.size()) { // all triggers have already been found
-                break;
-            }
-            timingMessages.emplace(tag.second);
-            consumeTags++;
-        }
-        timingInSpan.consumeTags(consumeTags);
-        timingInSpan.consume(consumeTags);
-
-        std::vector<gr::Tag> triggerTags;
-        triggerTags.reserve(triggerOffsets.size() + 1);
-        for (const auto triggerOffset : triggerOffsets) {
-            gr::property_map timing;
-            if (timingMessages.empty()) {
-                timing = gr::property_map{{gr::tag::TRIGGER_NAME.shortKey(), "UnknownTrigger"},   //
-                                                                                                  //{gr::tag::TRIGGER_OFFSET.shortKey(), 0.0f},        // fall back to ad-hoc timing message
-                    {gr::tag::TRIGGER_TIME.shortKey(), static_cast<std::uint64_t>(now.count())}}; //
-                // TODO: stop processing here instead in case the tag arrives later and only publish unknown trigger tag after timeout
-            } else {
-                // use timing message that we received over the message port if any
-                timing = timingMessages.front();
-                timingMessages.pop();
-            }
-            triggerTags.emplace_back(static_cast<int64_t>(triggerOffset), timing);
-            nextSystemtime = nowStamp + std::chrono::milliseconds(systemtime_interval);
-        }
-        // add an independent software timestamp with the localtime of the system to the last sample of each chunk
-        if (nowStamp > nextSystemtime) {
-            triggerTags.emplace_back(static_cast<int64_t>(availableSamples), gr::property_map{{gr::tag::TRIGGER_NAME.shortKey(), "systemtime"}, {gr::tag::TRIGGER_OFFSET.shortKey(), 0.0f}, {gr::tag::CONTEXT.shortKey(), "NO-CONTEXT"}, {gr::tag::TRIGGER_TIME.shortKey(), static_cast<uint64_t>(now.count())}});
-            nextSystemtime += std::chrono::milliseconds(systemtime_interval);
-        }
-
-        for (std::size_t channelIdx = 0; channelIdx < ps_state.channels.size(); ++channelIdx) {
-            auto&      channel         = ps_state.channels[channelIdx];
-            auto&      output          = outputs[channelIdx];
-            const auto writeSignalInfo = !channel.signal_info_written;
-            const auto tagsToWrite     = triggerTags.size() + (writeSignalInfo ? 1 : 0);
-            if (tagsToWrite == 0) {
-                continue;
-            }
-            if (writeSignalInfo) {
-                auto              map         = channel.toTagMap();
-                static const auto kSampleRate = std::string(gr::tag::SAMPLE_RATE.shortKey());
-                map[kSampleRate]              = pmtv::pmt(static_cast<float>(sample_rate));
-                output.publishTag(map, 0);
-                channel.signal_info_written = true;
-            }
-            if (publishNotEnoughSpaceInBuffer) {
-                gr::property_map map = gr::property_map{{"pico_not_enough_space_in_buffer", nrSamples - availableSamples}};
-                output.publishTag(map, 0);
-            }
-            for (auto& tag : triggerTags) {
-                output.publishTag(tag.map, tag.index);
-            }
-        }
-
-        // once all tags have been written, publish the data
-        for (std::size_t i = 0; i < outputs.size(); i++) {
-            // TODO: The issue is that the Block class does not properly handle optional ports such that sample limits are calculated wrongly.
-            // Therefore, we must connect all output ports of the picoscope and ensure that samples are published for all ports.
-            // Otherwise, tags will not be propagated correctly.
-            // const std::size_t nSamplesToPublish = i < ps_state.channels.size() ? availableSamples : 0UZ;
-            const std::size_t nSamplesToPublish = availableSamples;
-            outputs[i].publish(nSamplesToPublish);
-        }
-
-        ps_state.produced_worker += availableSamples;
     }
 
     void streamingCallback(int32_t nrSamplesSigned, uint32_t idx, int16_t overflow)
     requires(acquisitionMode == AcquisitionMode::Streaming)
     {
-        streamingSamples = static_cast<std::size_t>(nrSamplesSigned);
-        streamingOffset  = static_cast<std::size_t>(idx);
+        _streamingSamples = static_cast<std::size_t>(nrSamplesSigned);
+        _streamingOffset  = static_cast<std::size_t>(idx);
         // NOTE: according to the programmer's guide the data should be copied-out inside the callback function. Not sure if the driver might overwrite the buffer with new data after the callback has returned
         assert(nrSamplesSigned >= 0);
 
@@ -609,329 +460,333 @@ public:
             return;
         }
         this->invokeWork();
+        _canWorkArm.store(true);
     }
 
     template<gr::OutputSpanLike TOutSpan>
     gr::work::Status processBulk(gr::InputSpanLike auto& timingInSpan, std::span<TOutSpan>& outputs) {
         if constexpr (acquisitionMode == AcquisitionMode::Streaming) {
-            if (streamingSamples == 0) {
+            if (_streamingSamples == 0) {
                 for (auto& output : outputs) {
                     output.publish(0);
                 }
-                if (const auto ec = self().driver_poll()) {
+                if (const auto ec = self().streamingPoll()) {
                     this->emitErrorMessage("PicoscopeError", ec.message());
                     return gr::work::Status::ERROR;
                 }
             } else {
-                processDriverData(streamingSamples, streamingOffset, outputs, timingInSpan);
-                streamingSamples = 0;
+                processDriverDataStreaming(_streamingSamples, _streamingOffset, outputs, timingInSpan);
+                _streamingSamples = 0;
             }
         } else {
-            const auto samples = ps_settings.pre_samples + ps_settings.post_samples;
-            for (std::size_t capture = 0; capture < ps_settings.rapid_block_nr_captures; ++capture) {
-                const auto getValuesResult = self().driver_rapidBlockGetValues(capture, samples);
+            const auto        nSamples          = pre_samples + post_samples;
+            const std::size_t availableCaptures = calculateAvailableOutputs(n_captures, outputs);
+
+            for (std::size_t iCapture = 0; iCapture < availableCaptures; iCapture++) {
+                const auto getValuesResult = self().rapidBlockGetValues(iCapture, nSamples);
                 if (getValuesResult.error) {
                     this->emitErrorMessage("PicoscopeError", getValuesResult.error.message());
                     return gr::work::Status::ERROR;
                 }
+                processDriverDataRapidBlock(iCapture, getValuesResult.nSamples, outputs, timingInSpan);
+            }
 
-                // TODO handle overflow for individual channels?
-                processDriverData(getValuesResult.samples, 0, outputs, timingInSpan);
+            for (std::size_t i = 0; i < outputs.size(); i++) {
+                if (availableCaptures < n_captures) {
+                    outputs[i].publishTag(gr::property_map{{gr::tag::N_DROPPED_SAMPLES.shortKey(), nSamples * (n_captures - availableCaptures)}}, 0);
+                }
+                outputs[i].publish(n_captures);
             }
         }
-        if (ps_settings.trigger_once) {
-            ps_state.data_finished = true;
-        }
 
-        if (ps_state.channels.empty()) {
+        if (_channels.empty()) {
             return gr::work::Status::OK;
         }
 
-        if (ps_state.data_finished) {
+        if (trigger_once) {
             return gr::work::Status::DONE;
         }
 
         return gr::work::Status::OK;
     }
 
-    std::vector<std::size_t> findAnalogTriggers(const detail::Channel<T>& triggerChannel, std::span<const T> samples) {
-        if (samples.empty()) {
+    template<gr::OutputSpanLike TOutSpan>
+    [[nodiscard]] std::size_t calculateAvailableOutputs(std::size_t nSamples, std::span<TOutSpan>& outputs) const {
+        std::size_t availableOutputs = std::numeric_limits<std::size_t>::max();
+        for (std::size_t channelIdx = 0; channelIdx < _channels.size(); ++channelIdx) {
+            availableOutputs = std::min(availableOutputs, outputs[channelIdx].size());
+        }
+
+        const std::size_t availableSamples = std::min(availableOutputs, nSamples);
+        if (availableSamples < nSamples) {
+            fmt::println(std::cerr, "Picoscope::processDriverDataStreaming: {} samples will be lost due to insufficient space in output buffers (require {}, available {})", nSamples - availableSamples, nSamples, availableOutputs);
+        }
+
+        return availableSamples;
+    }
+
+    template<gr::OutputSpanLike TOutSpan>
+    void processDriverDataStreaming(std::size_t nSamples, std::size_t offset, std::span<TOutSpan>& outputs, gr::InputSpanLike auto& timingInSpan)
+    requires(acquisitionMode == AcquisitionMode::Streaming)
+    {
+        const std::size_t availableSamples = calculateAvailableOutputs(nSamples, outputs);
+
+        for (std::size_t channelIdx = 0; channelIdx < _channels.size(); channelIdx++) {
+            processSamplesOneChannel<T>(availableSamples, offset, _channels[channelIdx], outputs[channelIdx]);
+        }
+
+        const auto           triggerSourceIndex = self().convertToOutputIndex(trigger_source);
+        std::vector<gr::Tag> triggerTags        = triggerSourceIndex != std::nullopt ? processTimingTriggers<T>(availableSamples, outputs[triggerSourceIndex.value()], timingInSpan) : std::vector<gr::Tag>{};
+
+        // publish tags
+        for (std::size_t channelIdx = 0; channelIdx < _channels.size(); ++channelIdx) {
+            auto&      channel     = _channels[channelIdx];
+            auto&      output      = outputs[channelIdx];
+            const auto tagsToWrite = triggerTags.size() + (channel.signalInfoTagPublished ? 0 : 1);
+            if (tagsToWrite == 0) {
+                continue;
+            }
+            if (!channel.signalInfoTagPublished) {
+                output.publishTag(channel.toTagMap(), 0);
+                channel.signalInfoTagPublished = true;
+            }
+            if (availableSamples < nSamples) {
+                output.publishTag(gr::property_map{{gr::tag::N_DROPPED_SAMPLES.shortKey(), nSamples - availableSamples}}, 0);
+            }
+            for (auto& tag : triggerTags) {
+                output.publishTag(tag.map, tag.index);
+            }
+        }
+
+        // publish samples
+        for (std::size_t i = 0; i < outputs.size(); i++) {
+            // TODO: The issue is that the Block class does not properly handle optional ports such that sample limits are calculated wrongly.
+            // Therefore, we must connect all output ports of the picoscope and ensure that samples are published for all ports.
+            // Otherwise, tags will not be propagated correctly.
+            // const std::size_t nSamplesToPublish = i < _state.channels.size() ? availableSamples : 0UZ;
+            const std::size_t nSamplesToPublish = availableSamples;
+            outputs[i].publish(nSamplesToPublish);
+        }
+
+        _nSamplesPublished += availableSamples;
+    }
+
+    constexpr T createDataset(detail::Channel& channel, std::size_t nSamples)
+    requires(acquisitionMode == AcquisitionMode::RapidBlock)
+    {
+        T ds{};
+        ds.timestamp = 0;
+
+        ds.axis_names = {channel.name};
+        ds.axis_units = {channel.unit};
+
+        ds.extents           = {1, static_cast<int32_t>(nSamples)};
+        ds.layout            = gr::LayoutRight{};
+        ds.signal_names      = {channel.name};
+        ds.signal_units      = {channel.unit};
+        ds.signal_quantities = {channel.quantity};
+
+        ds.signal_values.resize(nSamples);
+        ds.signal_ranges.resize(1);
+        ds.timing_events.resize(1);
+
+        if (!channel.signalInfoTagPublished) {
+            ds.meta_information.resize(1);
+            ds.meta_information[0]         = channel.toTagMap();
+            channel.signalInfoTagPublished = true;
+        }
+
+        return ds;
+    }
+
+    template<gr::OutputSpanLike TOutSpan>
+    void processDriverDataRapidBlock(std::size_t iCapture, std::size_t nSamples, std::span<TOutSpan>& outputs, gr::InputSpanLike auto& timingInSpan)
+    requires(acquisitionMode == AcquisitionMode::RapidBlock)
+    {
+        using TSample = T::value_type;
+        for (std::size_t channelIdx = 0; channelIdx < _channels.size(); channelIdx++) {
+            outputs[channelIdx][iCapture] = createDataset(_channels[channelIdx], nSamples);
+            processSamplesOneChannel<TSample>(nSamples, 0, _channels[channelIdx], outputs[channelIdx][iCapture].signal_values);
+            if (!outputs[channelIdx][iCapture].signal_values.empty()) {
+                // gr::dataset::updateMinMax<TSample>(outputs[channelIdx][iCapture]); // TODO: fix compilation error, unsupported type: UncertainValue
+            }
+        }
+
+        const auto           triggerSourceIndex = self().convertToOutputIndex(trigger_source);
+        std::vector<gr::Tag> triggerTags        = triggerSourceIndex != std::nullopt ? processTimingTriggers<TSample>(nSamples, outputs[triggerSourceIndex.value()][iCapture].signal_values, timingInSpan) : std::vector<gr::Tag>{};
+
+        for (std::size_t channelIdx = 0; channelIdx < _channels.size(); ++channelIdx) {
+            for (auto& tag : triggerTags) {
+                outputs[channelIdx][iCapture].timing_events[0].emplace_back(tag.index, tag.map);
+            }
+        }
+
+        _nSamplesPublished++;
+    }
+
+    template<typename TSample>
+    void processSamplesOneChannel(std::size_t availableSamples, std::size_t offset, detail::Channel& channel, std::span<TSample> output) {
+
+        const auto driverData = std::span(channel.driverBuffer).subspan(offset, availableSamples);
+
+        if constexpr (std::is_same_v<T, int16_t>) {
+            std::ranges::copy(driverData, output.begin());
+        } else {
+            const float voltageMultiplier = channel.range / static_cast<float>(_maxValue);
+            // TODO use SIMD
+            for (std::size_t i = 0; i < availableSamples; ++i) {
+                if constexpr (std::is_same_v<T, float>) {
+                    output[i] = channel.offset + channel.scale * voltageMultiplier * static_cast<float>(driverData[i]);
+                } else if constexpr (std::is_same_v<T, gr::UncertainValue<float>>) {
+                    output[i] = gr::UncertainValue(channel.offset + channel.scale * voltageMultiplier * static_cast<float>(driverData[i]), self().uncertainty());
+                }
+            }
+        }
+    }
+
+    template<typename TSample>
+    std::vector<gr::Tag> processTimingTriggers(std::size_t availableSamples, std::span<TSample> samples, gr::InputSpanLike auto& timingInSpan) {
+        // Note reference for `gr::InputSpanLike auto& timingInSpan` is needed for proper work of consumeTags method
+        std::vector<std::size_t> triggerOffsets;
+        const auto               triggerSourceIndex = self().convertToOutputIndex(trigger_source);
+        if (triggerSourceIndex != std::nullopt) {
+            triggerOffsets = findAnalogTriggers<TSample>(_channels[triggerSourceIndex.value()], samples, availableSamples);
+        }
+
+        const auto now = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now().time_since_epoch());
+
+        std::size_t consumeTags = 0UZ;
+        for (const auto& tag : timingInSpan.tags()) {
+            if (!tag.second.contains("GID")) { // only consider timing tags
+                consumeTags++;
+                continue;
+            }
+            // TODO: Allow to match multiple events to a single trigger here and allow to timeout on events where the trigger pulse was somehow lost
+            if (triggerOffsets.size() <= _timingMessages.size()) { // all triggers have already been found
+                break;
+            }
+            _timingMessages.emplace(tag.second);
+            consumeTags++;
+        }
+        timingInSpan.consumeTags(consumeTags);
+        timingInSpan.consume(consumeTags);
+
+        std::vector<gr::Tag> triggerTags;
+        triggerTags.reserve(triggerOffsets.size() + 1);
+        for (const auto triggerOffset : triggerOffsets) {
+            gr::property_map timing;
+            if (_timingMessages.empty()) {
+                timing = gr::property_map{{gr::tag::TRIGGER_NAME.shortKey(), "UnknownTrigger"}, {gr::tag::TRIGGER_TIME.shortKey(), static_cast<std::uint64_t>(now.count())}, {gr::tag::TRIGGER_OFFSET.shortKey(), static_cast<std::uint64_t>(0)}};
+                // TODO: stop processing here instead in case the tag arrives later and only publish unknown trigger tag after timeout
+            } else {
+                timing = _timingMessages.front();
+                _timingMessages.pop();
+            }
+            triggerTags.emplace_back(static_cast<int64_t>(triggerOffset), timing);
+        }
+        // add an independent software timestamp with the localtime of the system to the last sample of each chunk
+        triggerTags.emplace_back(static_cast<int64_t>(availableSamples), gr::property_map{{gr::tag::TRIGGER_NAME.shortKey(), "systemtime"}, {gr::tag::TRIGGER_TIME.shortKey(), static_cast<uint64_t>(now.count())}});
+
+        return triggerTags;
+    }
+
+    template<typename TSample>
+    std::vector<std::size_t> findAnalogTriggers(const detail::Channel& triggerChannel, std::span<TSample>& samples, std::size_t available) {
+        if (samples.empty() || samples.size() < available) {
             return {};
         }
 
         std::vector<std::size_t> triggerOffsets; // relative offset of detected triggers
-        const float              band              = triggerChannel.settings.range / 100.f;
-        const float              voltageMultiplier = triggerChannel.settings.range / static_cast<float>(ps_state.max_value);
+        const float              band              = triggerChannel.range / 100.f;
+        const float              voltageMultiplier = triggerChannel.range / static_cast<float>(_maxValue);
 
-        const auto toFloat = [&voltageMultiplier, &triggerChannel](T raw) {
-            if constexpr (std::is_same_v<T, float>) {
-                return triggerChannel.settings.offset + triggerChannel.settings.scale * voltageMultiplier * raw;
-            } else if constexpr (std::is_same_v<T, int16_t>) {
+        const auto toFloat = [&voltageMultiplier, &triggerChannel](TSample raw) {
+            if constexpr (std::is_same_v<TSample, float>) {
+                return triggerChannel.offset + triggerChannel.scale * voltageMultiplier * raw;
+            } else if constexpr (std::is_same_v<TSample, int16_t>) {
                 return raw;
-            } else if constexpr (std::is_same_v<T, int16_t>) {
-                return static_cast<float>(raw);
-            } else if constexpr (std::is_same_v<T, gr::UncertainValue<float>>) {
-                return triggerChannel.settings.offset + triggerChannel.settings.scale * voltageMultiplier * raw.value;
+            } else if constexpr (std::is_same_v<TSample, gr::UncertainValue<float>>) {
+                return triggerChannel.offset + triggerChannel.scale * voltageMultiplier * raw.value;
             } else {
-                static_assert(gr::meta::always_false<T>, "This type is not supported.");
+                static_assert(gr::meta::always_false<TSample>, "This type is not supported.");
             }
         };
 
-        if (ps_settings.trigger.direction == TriggerDirection::Rising || ps_settings.trigger.direction == TriggerDirection::High) {
-            for (std::size_t i = 0; i < samples.size(); i++) {
+        const auto triggerDirectionEnum = detail::convertToEnum<TriggerDirection>(trigger_direction);
+        if (triggerDirectionEnum == TriggerDirection::Rising || triggerDirectionEnum == TriggerDirection::High) {
+            for (std::size_t i = 0; i < available; i++) {
                 const float value = toFloat(samples[i]);
-                if (ps_state.trigger_state == 0 && value >= ps_settings.trigger.threshold) {
-                    ps_state.trigger_state = 1;
+                if (_triggerState == 0 && value >= trigger_threshold) {
+                    _triggerState = 1;
                     triggerOffsets.push_back(i);
-                } else if (ps_state.trigger_state == 1 && value <= ps_settings.trigger.threshold - band) {
-                    ps_state.trigger_state = 0;
+                } else if (_triggerState == 1 && value <= trigger_threshold - band) {
+                    _triggerState = 0;
                 }
             }
-        } else if (ps_settings.trigger.direction == TriggerDirection::Falling || ps_settings.trigger.direction == TriggerDirection::Low) {
-            for (std::size_t i = 0; i < samples.size(); i++) {
+        } else if (triggerDirectionEnum == TriggerDirection::Falling || triggerDirectionEnum == TriggerDirection::Low) {
+            for (std::size_t i = 0; i < available; i++) {
                 const float value = toFloat(samples[i]);
-                if (ps_state.trigger_state == 1 && value <= ps_settings.trigger.threshold) {
-                    ps_state.trigger_state = 0;
+                if (_triggerState == 1 && value <= trigger_threshold) {
+                    _triggerState = 0;
                     triggerOffsets.push_back(i);
-                } else if (ps_state.trigger_state == 0 && value >= ps_settings.trigger.threshold + band) {
-                    ps_state.trigger_state = 1;
+                } else if (_triggerState == 0 && value >= trigger_threshold + band) {
+                    _triggerState = 1;
                 }
             }
         }
         return triggerOffsets;
     }
 
-    constexpr void validateDesiredActualFrequency(float desiredFreq, float actualFreq) {
-        // In order to prevent exceptions/exit due to rounding errors, we don't directly compare actual_freq to desired_freq, but instead allow a difference up to 0.001%
-        constexpr float kMaxDiffPercentage = 0.001f;
-        const float     diff               = actualFreq / desiredFreq - 1.f;
-        if (std::abs(diff) > kMaxDiffPercentage) {
-            throw std::runtime_error(fmt::format("Desired and actual frequency do not match. desired: {} actual: {}", desiredFreq, actualFreq));
-        }
+    [[nodiscard]] constexpr int16_t convertVoltageToADCCount(float value) {
+        const float rangeMax = 5.f;
+        value                = std::clamp(value, -rangeMax, rangeMax);
+        return static_cast<int16_t>((value / rangeMax) * self().maxADCCount());
     }
 
-    constexpr int16_t convertVoltageToRawLogicValue(float value) {
-        constexpr float kMaxLogicalVoltage = 5.0;
-
-        if (value > kMaxLogicalVoltage) {
-            throw std::invalid_argument(fmt::format("Maximum logical level is: {}, received: {}.", kMaxLogicalVoltage, value));
-        }
-        // Note max channel value not provided with PicoScope API, we use ext max value
-        return static_cast<int16_t>(value / kMaxLogicalVoltage * self().maxVoltage());
-    }
-
-    Error driver_initialize() {
-        PICO_STATUS status;
-
-        // Required to force sequence execution of open unit calls...
-        std::lock_guard initGuard{g_init_mutex};
-
-        status = self().openUnit(this->ps_settings.serial_number);
-
-        // ignore ext. power not connected error/warning
-        if (status == PICO_POWER_SUPPLY_NOT_CONNECTED || status == PICO_USB3_0_DEVICE_NON_USB3_0_PORT) {
-            status = self().changePowerSource(this->ps_state.handle, status);
-            if (status == PICO_POWER_SUPPLY_NOT_CONNECTED || status == PICO_USB3_0_DEVICE_NON_USB3_0_PORT) {
-                status = self().changePowerSource(this->ps_state.handle, status);
-            }
-        }
-
-        if (status != PICO_OK) {
-            fmt::println(std::cerr, "open unit failed: {} ", detail::getErrorMessage(status));
-            return {status};
-        }
-
-        // maximum value is used for conversion to volts
-        status = self().maximumValue(this->ps_state.handle, &this->ps_state.max_value);
-        if (status != PICO_OK) {
-            self().closeUnit(this->ps_state.handle);
-            fmt::println(std::cerr, "maximumValue: {}", detail::getErrorMessage(status));
-            return {status};
-        }
-
-        return {};
-    }
-
-    Error driver_close() {
-        if (this->ps_state.handle == -1) {
-            return {};
-        }
-
-        auto status           = self().closeUnit(this->ps_state.handle);
-        this->ps_state.handle = -1;
-
-        if (status != PICO_OK) {
-            fmt::println(std::cerr, "closeUnit: {}", detail::getErrorMessage(status));
-        }
-        return {status};
-    }
-
-    Error driver_configure() {
-        int32_t maxSamples;
-        auto    status = self().memorySegments(this->ps_state.handle, static_cast<uint32_t>(this->ps_settings.rapid_block_nr_captures), &maxSamples);
-        if (status != PICO_OK) {
-            fmt::println(std::cerr, "MemorySegments: {}", detail::getErrorMessage(status));
-            return {status};
-        }
-
-        if constexpr (acquisitionMode == AcquisitionMode::RapidBlock) {
-            status = self().setNoOfCaptures(this->ps_state.handle, static_cast<uint32_t>(this->ps_settings.rapid_block_nr_captures));
-            if (status != PICO_OK) {
-                fmt::println(std::cerr, "SetNoOfCaptures: {}", detail::getErrorMessage(status));
-                return {status};
-            }
-        }
-
-        // configure analog channels
-        for (const auto& channel : this->ps_state.channels) {
-            const auto idx = self().convertToChannel(channel.id);
-            assert(idx);
-            const auto coupling = self().convertToCoupling(channel.settings.coupling);
-            const auto range    = self().convertToRange(channel.settings.range);
-
-            status = self().setChannel(this->ps_state.handle, *idx, true, coupling, static_cast<TPSImpl::ChannelRangeType>(range), static_cast<float>(channel.settings.analogOffset));
-            if (status != PICO_OK) {
-                fmt::println(std::cerr, "SetChannel (chan '{}'): {}", channel.id, detail::getErrorMessage(status));
-                return {status};
-            }
-        }
-
-        // apply trigger configuration
-        if (this->ps_settings.trigger.isAnalog() && acquisitionMode == AcquisitionMode::RapidBlock) {
-            const auto channel = self().convertToChannel(this->ps_settings.trigger.source);
-            assert(channel);
-            status = self().setSimpleTrigger(this->ps_state.handle,
-                true, // enable
-                *channel, convertVoltageToRawLogicValue(this->ps_settings.trigger.threshold), self().convertToThresholdDirection(this->ps_settings.trigger.direction),
-                0,   // delay
-                -1); // auto trigger
-            if (status != PICO_OK) {
-                fmt::println(std::cerr, "setSimpleTrigger: {}", detail::getErrorMessage(status));
-                return {status};
-            }
-        } else {
-            // disable triggers
-            for (int i = 0; i < self().maxChannel(); i++) {
-                typename TPSImpl::ConditionType cond;
-                cond.source    = static_cast<TPSImpl::ChannelType>(i);
-                cond.condition = self().conditionDontCare();
-                status         = self().setTriggerChannelConditions(this->ps_state.handle, &cond, 1, self().conditionsInfoClear());
-                if (status != PICO_OK) {
-                    fmt::println(std::cerr, "SetTriggerChannelConditionsV2: {}", detail::getErrorMessage(status));
-                    return {status};
-                }
-            }
-        }
-
-        return {};
-    }
-
-    Error driver_disarm() noexcept {
-        if (const auto status = self().driver_stop(this->ps_state.handle); status != PICO_OK) {
-            fmt::println(std::cerr, "Stop: {}", detail::getErrorMessage(status));
-            return {status};
-        }
-
-        return {};
-    }
-
-    Error driver_arm() {
-        if constexpr (acquisitionMode == AcquisitionMode::RapidBlock) {
-            auto timebaseResult               = self().convertSampleRateToTimebase(this->ps_state.handle, this->ps_settings.sample_rate);
-            this->ps_state.actual_sample_rate = timebaseResult.actualFreq;
-            fmt::println("RapidBlock mode - desired sample rate:{}, actual sample rate:{}", this->ps_settings.sample_rate, this->ps_state.actual_sample_rate);
-
-            static auto redirector = [](int16_t, PICO_STATUS status, void* vobj) { static_cast<decltype(this)>(vobj)->rapidBlockCallback({status}); };
-
-            auto status = self().runBlock(                            //
-                this->ps_state.handle,                                // identifier for the scope device
-                static_cast<int32_t>(this->ps_settings.pre_samples),  // number of samples before trigger event
-                static_cast<int32_t>(this->ps_settings.post_samples), // number of samples after trigger event
-                timebaseResult.timebase,                              // timebase
-                nullptr,                                              // time indispossed
-                0,                                                    // segment index
-                static_cast<TPSImpl::BlockReadyType>(redirector),     // BlockReady() callback
-                this);
-
-            if (status != PICO_OK) {
-                fmt::println(std::cerr, "RunBlock: {}", detail::getErrorMessage(status));
-                return {status};
-            }
-        } else {
-            using fair::picoscope::detail::kDriverBufferSize;
-            self().setBuffers(kDriverBufferSize, 0);
-
-            TimeInterval timeInterval = convertSampleRateToTimeInterval(this->ps_settings.sample_rate);
-
-            auto status = self().runStreaming(              //
-                this->ps_state.handle,                      // identifier for the scope device
-                &timeInterval.interval,                     // in: desired interval, out: actual interval
-                self().convertTimeUnits(timeInterval.unit), // time unit of interval
-                0,                                          // pre-trigger-samples (unused)
-                static_cast<uint32_t>(kDriverBufferSize),   // post-trigger-samples
-                false,                                      // autoStop
-                1,                                          // downsampling ratio // TODO: reconsider if we need downsampling support
-                self().ratioNone(),                         // downsampling ratio mode
-                static_cast<uint32_t>(kDriverBufferSize));  // the size of the overview buffers
-
-            if (status != PICO_OK) {
-                fmt::println(std::cerr, "RunStreaming: {}", detail::getErrorMessage(status));
-                return {status};
-            }
-            // calculate actual sample rate
-            this->ps_state.actual_sample_rate = convertTimeIntervalToSampleRate(timeInterval);
-            fmt::println("Streaming mode - desired sample rate:{}, actual sample rate:{}", this->ps_settings.sample_rate, this->ps_state.actual_sample_rate);
-        }
-
-        return {};
-    }
-
-    Error driver_poll() {
+    [[nodiscard]] Error streamingPoll() {
         static auto redirector = [](int16_t /*handle*/, int32_t noOfSamples, uint32_t startIndex, int16_t overflow, uint32_t /*triggerAt*/, int16_t /*triggered*/, int16_t /*autoStop*/, void* vobj) { static_cast<decltype(this)>(vobj)->streamingCallback(noOfSamples, startIndex, overflow); };
 
-        const auto status = self().getStreamingLatestValues(this->ps_state.handle, static_cast<TPSImpl::StreamingReadyType>(redirector), this);
+        const auto status = self().getStreamingLatestValues(_handle, static_cast<TPSImpl::StreamingReadyType>(redirector), this);
         if (status == PICO_BUSY || status == PICO_DRIVER_FUNCTION) {
             return {};
         }
         return {status};
     }
 
-    fair::picoscope::GetValuesResult driver_rapidBlockGetValues(std::size_t capture, std::size_t samples) {
-        if (const auto ec = self().setBuffers(samples, static_cast<uint32_t>(capture)); ec) {
+    [[nodiscard]] fair::picoscope::GetValuesResult rapidBlockGetValues(std::size_t iCapture, std::size_t nSamples) {
+        if (const auto ec = self().setBuffers(nSamples, static_cast<uint32_t>(iCapture)); ec) {
             return {ec, 0, 0};
         }
 
-        auto       nrSamples = static_cast<uint32_t>(samples);
-        int16_t    overflow  = 0;
-        const auto status    = self().getValues(this->ps_state.handle,
-               0, // offset
-               &nrSamples, 1, self().ratioNone(), static_cast<uint32_t>(capture), &overflow);
+        const uint32_t offset     = 0;
+        auto           nSamples32 = static_cast<uint32_t>(nSamples);
+        int16_t        overflow   = 0;
+        const auto     status     = self().getValues(_handle, offset, &nSamples32, 1, self().ratioNone(), static_cast<uint32_t>(iCapture), &overflow);
+
         if (status != PICO_OK) {
             fmt::println(std::cerr, "GetValues: {}", detail::getErrorMessage(status));
             return {{status}, 0, 0};
         }
-
-        return {{}, static_cast<std::size_t>(nrSamples), overflow};
+        return {{}, static_cast<std::size_t>(nSamples32), overflow};
     }
 
-    Error setBuffers(size_t samples, uint32_t blockNumber) {
-        for (auto& channel : this->ps_state.channels) {
-            const auto channelIndex = self().convertToChannel(channel.id);
-            assert(channelIndex);
+    [[nodiscard]] Error setBuffers(size_t nSamples, uint32_t segmentIndex) {
+        for (auto& channel : _channels) {
+            const auto channelEnum = self().convertToChannel(channel.id);
+            assert(channelEnum);
 
-            channel.driver_buffer.resize(std::max(samples, channel.driver_buffer.size()));
-            const auto status = self().setDataBuffer(this->ps_state.handle, *channelIndex, channel.driver_buffer.data(), static_cast<int32_t>(samples), blockNumber, self().ratioNone());
+            channel.driverBuffer.resize(std::max(nSamples, channel.driverBuffer.size()));
+            const auto status = self().setDataBuffer(_handle, *channelEnum, channel.driverBuffer.data(), static_cast<int32_t>(nSamples), segmentIndex, self().ratioNone());
 
             if (status != PICO_OK) {
-                fmt::println(std::cerr, "SetDataBuffer (chan {}): {}", static_cast<std::size_t>(*channelIndex), detail::getErrorMessage(status));
+                fmt::println(std::cerr, "SetDataBuffer (chan {}): {}", static_cast<std::size_t>(*channelEnum), detail::getErrorMessage(status));
                 return {status};
             }
         }
-
         return {};
     }
 
-    std::string getUnitInfoTopic(int16_t handle, PICO_INFO info) const {
+    [[nodiscard]] std::string getUnitInfoTopic(int16_t handle, PICO_INFO info) const {
         std::array<int8_t, 40> line{};
         int16_t                requiredSize;
 
@@ -943,9 +798,9 @@ public:
         return {};
     }
 
-    std::string driver_driverVersion() const {
+    [[nodiscard]] std::string driverVersion() const {
         const std::string prefix  = "Picoscope Linux Driver, ";
-        auto              version = getUnitInfoTopic(this->ps_state.handle, PICO_DRIVER_VERSION);
+        auto              version = getUnitInfoTopic(_handle, PICO_DRIVER_VERSION);
 
         if (auto i = version.find(prefix); i != std::string::npos) {
             version.erase(i, prefix.length());
@@ -953,27 +808,9 @@ public:
         return version;
     }
 
-    std::string driver_hardwareVersion() const {
-        if (!this->ps_state.initialized) {
-            return {};
-        }
-        return getUnitInfoTopic(this->ps_state.handle, PICO_HARDWARE_VERSION);
-    }
+    [[nodiscard]] std::string hardwareVersion() const { return getUnitInfoTopic(_handle, PICO_HARDWARE_VERSION); }
 
-    std::string driver_serialNumber() const {
-        if (!this->ps_state.initialized) {
-            return {};
-        }
-        return getUnitInfoTopic(this->ps_state.handle, PICO_BATCH_AND_SERIAL);
-    }
-
-    std::optional<std::size_t> driver_channelIdToIndex(std::string_view id) {
-        const auto channel = self().convertToChannel(id);
-        if (!channel) {
-            return {};
-        }
-        return static_cast<std::size_t>(*channel);
-    }
+    [[nodiscard]] std::string serialNumber() const { return getUnitInfoTopic(_handle, PICO_BATCH_AND_SERIAL); }
 
     [[nodiscard]] constexpr auto& self() noexcept { return *static_cast<TPSImpl*>(this); }
 

--- a/blocklib/picoscope/Picoscope.hpp
+++ b/blocklib/picoscope/Picoscope.hpp
@@ -838,17 +838,18 @@ public:
         for (const auto triggerOffset : triggerOffsets) {
             gr::property_map timing;
             if (_timingMessages.empty()) {
-                timing = gr::property_map{{gr::tag::TRIGGER_NAME.shortKey(), "UnknownTrigger"}, {gr::tag::TRIGGER_TIME.shortKey(), static_cast<std::uint64_t>(now.count())}, {gr::tag::TRIGGER_OFFSET.shortKey(), static_cast<std::uint64_t>(0)}};
+                timing = gr::property_map{{gr::tag::TRIGGER_NAME.shortKey(), "UnknownTrigger"}, {gr::tag::TRIGGER_TIME.shortKey(), static_cast<std::uint64_t>(now.count())}, {gr::tag::TRIGGER_OFFSET.shortKey(), 0.0f}};
                 // TODO: stop processing here instead in case the tag arrives later and only publish unknown trigger tag after timeout
             } else {
                 timing = _timingMessages.front();
                 _timingMessages.pop();
             }
             triggerTags.emplace_back(static_cast<int64_t>(triggerOffset), timing);
+            _nextSystemtime = nowStamp + std::chrono::milliseconds(systemtime_interval);
         }
         // add an independent software timestamp with the localtime of the system to the last sample of each chunk
         if (nowStamp > _nextSystemtime) {
-            triggerTags.emplace_back(static_cast<int64_t>(availableSamples), gr::property_map{{gr::tag::TRIGGER_NAME.shortKey(), "systemtime"}, {gr::tag::TRIGGER_TIME.shortKey(), static_cast<uint64_t>(now.count())}});
+            triggerTags.emplace_back(static_cast<int64_t>(availableSamples), gr::property_map{{gr::tag::TRIGGER_NAME.shortKey(), "systemtime"}, {gr::tag::TRIGGER_OFFSET.shortKey(), 0.0f}, {gr::tag::CONTEXT.shortKey(), "NO-CONTEXT"}, {gr::tag::TRIGGER_TIME.shortKey(), static_cast<uint64_t>(now.count())}});
             _nextSystemtime += std::chrono::milliseconds(systemtime_interval);
         }
         return triggerTags;

--- a/blocklib/picoscope/Picoscope.hpp
+++ b/blocklib/picoscope/Picoscope.hpp
@@ -205,8 +205,8 @@ struct Picoscope : public PicoscopeBlockingHelper<TPSImpl, gr::DataSetLike<T>>::
     A<std::string, "arm trigger: `<trigger_name>/<ctx>`, if empty not used">    trigger_arm                = ""; // RapidBlock mode only
     A<std::string, "disarm trigger: `<trigger_name>/<ctx>`, if empty not used"> trigger_disarm             = ""; // RapidBlock mode only
     A<gr::Size_t, "time between two systemtime tags in ms">                     systemtime_interval        = 1000UZ;
-    A<int16_t, "digital port threshold (ADC: –32767 (–5 V) to 32767 (+5 V))">   digital_port_threshold     = 0;    // only used if digital port are available: 3000, 5000, 6000 series
-    A<bool, "invert digital port output">                                       digital_port_invert_output = true; // only used if digital port are available: 3000, 5000, 6000 series
+    A<int16_t, "digital port threshold (ADC: –32767 (–5 V) to 32767 (+5 V))">   digital_port_threshold     = 0;     // only used if digital port are available: 3000, 5000, 6000 series
+    A<bool, "invert digital port output">                                       digital_port_invert_output = false; // only used if digital port are available: 3000, 5000, 6000 series
 
     gr::PortIn<std::uint8_t, gr::Async> timingIn;
 
@@ -219,7 +219,7 @@ struct Picoscope : public PicoscopeBlockingHelper<TPSImpl, gr::DataSetLike<T>>::
 
     GR_MAKE_REFLECTABLE(Picoscope, timingIn, digitalOut, serial_number, sample_rate, pre_samples, post_samples, n_captures, streaming_mode_poll_rate,                                 //
         auto_arm, trigger_once, channel_ids, signal_names, signal_units, signal_quantities, channel_ranges, channel_analog_offsets, signal_scales, signal_offsets, channel_couplings, //
-        trigger_source, trigger_threshold, trigger_direction, digital_port_threshold, trigger_arm, trigger_disarm, systemtime_interval);
+        trigger_source, trigger_threshold, trigger_direction, digital_port_threshold, digital_port_invert_output, trigger_arm, trigger_disarm, systemtime_interval);
 
 private:
     std::atomic<std::size_t>                       _streamingSamples = 0UZ;
@@ -396,6 +396,7 @@ public:
             }
             serial_number = serialNumber();
             fmt::println("Picoscope serial number: {}", serial_number);
+            fmt::println("Picoscope device variant: {}", deviceVariant());
         } catch (const std::exception& e) {
             fmt::println(std::cerr, "{}", e.what());
         }
@@ -976,6 +977,8 @@ public:
     [[nodiscard]] std::string hardwareVersion() const { return getUnitInfoTopic(_handle, PICO_HARDWARE_VERSION); }
 
     [[nodiscard]] std::string serialNumber() const { return getUnitInfoTopic(_handle, PICO_BATCH_AND_SERIAL); }
+
+    [[nodiscard]] std::string deviceVariant() const { return getUnitInfoTopic(_handle, PICO_VARIANT_INFO); }
 
     [[nodiscard]] constexpr auto& self() noexcept { return *static_cast<TPSImpl*>(this); }
 

--- a/blocklib/picoscope/Picoscope3000a.hpp
+++ b/blocklib/picoscope/Picoscope3000a.hpp
@@ -1,0 +1,320 @@
+#ifndef FAIR_PICOSCOPE_PICOSCOPE3000A_HPP
+#define FAIR_PICOSCOPE_PICOSCOPE3000A_HPP
+
+#include <Picoscope.hpp>
+
+#include <ps3000aApi.h>
+
+namespace fair::picoscope {
+
+// These structures are not available for 3000A API.
+// We implemented them for consistency.
+typedef struct tPS3000ACondition {
+    PS3000A_CHANNEL       source;
+    PS3000A_TRIGGER_STATE condition;
+} PS3000A_CONDITION;
+
+typedef enum enPS4000AConditionsInfo { PS3000A_CLEAR = 0x00000001, PS3000A_ADD = 0x00000002 } PS3000A_CONDITIONS_INFO;
+
+typedef enum enPS3000ADeviceResolution { PS3000A_DR_8BIT } PS3000A_DEVICE_RESOLUTION;
+
+template<typename T>
+struct Picoscope3000a : public fair::picoscope::Picoscope<T, Picoscope3000a<T>> {
+    using super_t = fair::picoscope::Picoscope<T, Picoscope3000a<T>>;
+
+    Picoscope3000a(gr::property_map props) : super_t(std::move(props)) {}
+
+    std::vector<gr::PortOut<T>> out{4};
+
+    GR_MAKE_REFLECTABLE(Picoscope3000a, out);
+
+private:
+    std::array<std::vector<int16_t>, 2> _digitalBuffers;
+
+public:
+    using ChannelType            = PS3000A_CHANNEL;
+    using ConditionType          = PS3000A_CONDITION;
+    using CouplingType           = PS3000A_COUPLING;
+    using RangeType              = PS3000A_RANGE;
+    using ChannelRangeType       = RangeType;
+    using ThresholdDirectionType = PS3000A_THRESHOLD_DIRECTION;
+    using TriggerStateType       = PS3000A_TRIGGER_STATE;
+    using ConditionsInfoType     = PS3000A_CONDITIONS_INFO;
+    using TimeUnitsType          = PS3000A_TIME_UNITS;
+    using StreamingReadyType     = ps3000aStreamingReady;
+    using BlockReadyType         = ps3000aBlockReady;
+    using RatioModeType          = PS3000A_RATIO_MODE;
+    using DeviceResolutionType   = PS3000A_DEVICE_RESOLUTION;
+
+    TimeUnitsType convertTimeUnits(TimeUnits tu) const {
+        switch (tu) {
+        case TimeUnits::fs: return PS3000A_FS;
+        case TimeUnits::ps: return PS3000A_PS;
+        case TimeUnits::ns: return PS3000A_NS;
+        case TimeUnits::us: return PS3000A_US;
+        case TimeUnits::ms: return PS3000A_MS;
+        case TimeUnits::s: return PS3000A_S;
+        }
+        return PS3000A_MAX_TIME_UNITS;
+    }
+
+    [[nodiscard]] constexpr TimebaseResult convertSampleRateToTimebase(int16_t /*handle*/, float desiredFreq) {
+        // https://www.picotech.com/download/manuals/picoscope-3000-series-a-api-programmers-guide.pdf, page 15
+
+        // For PicoScope 3000A / 3000D Series
+        // -----------------------------------------------------------------------------------------
+        // | Timebase (n)| Sampling Interval (tS)                       | Sampling Frequency (fS)  |
+        // |-------------|----------------------------------------------|--------------------------|
+        // |     0       | 1 ns   2^0 / 1 GHz                           | 1 GHz                    |
+        // |     1       | 2 ns   2^1 / 1 GHz                           | 500 MHz                  |
+        // |     2       | 4 ns   2^2 / 1 GHz                           | 250 MHz                  |
+        // |     3       | 8 ns   (n - 2)/125 MHz                       | 125 MHz                  |
+        // |    ...      | ...                                          | ...                      |
+        // | 2^32 - 1    | ~34.4 s ((2^32 - 1) - 2)/125 MHz             | ~0.029 Hz                |
+        // -----------------------------------------------------------------------------------------
+        //  Notes:
+        //   • The maximum sampling rate (minimum tS) depends on the number of enabled channels
+        //     and digital ports. See the PicoScope 3000 Series data sheet for details.
+        //   • In streaming mode, USB speed and the specific oscilloscope model may further limit
+        //     the maximum real-time sampling rate.
+
+        if (desiredFreq <= 0.f || desiredFreq >= 1.e9f) {
+            return {0, 1.e9f};
+        } else if (desiredFreq >= 500.e6f) {
+            return {1, 500.e6f};
+        } else if (desiredFreq >= 250.e6f) {
+            return {2, 250.e6f};
+        } else {
+            const auto  timebase   = static_cast<uint32_t>((125.e6f / desiredFreq) + 2); // n = (125 MHz / f_S) + 2;
+            const float actualFreq = 125.e6f / static_cast<float>(timebase - 2);
+            return {timebase, actualFreq};
+        }
+    }
+
+    static constexpr std::optional<std::size_t> convertToOutputIndex(std::string_view source) {
+        static constexpr std::array<std::pair<std::string_view, std::size_t>, 4> channelMap{{{"A", 0}, {"B", 1}, {"C", 2}, {"D", 3}}};
+
+        const auto it = std::ranges::find_if(channelMap, [source](auto&& kv) { return kv.first == source; });
+        if (it != channelMap.end()) {
+            return it->second;
+        }
+        return std::nullopt;
+    }
+
+    static constexpr std::optional<ChannelType> convertToChannel(std::string_view source) {
+        static constexpr std::array<std::pair<std::string_view, ChannelType>, 5> channelMap{{//
+            {"A", PS3000A_CHANNEL_A}, {"B", PS3000A_CHANNEL_B}, {"C", PS3000A_CHANNEL_C}, {"D", PS3000A_CHANNEL_D}, {"EXTERNAL", PS3000A_EXTERNAL}}};
+
+        const auto it = std::ranges::find_if(channelMap, [source](auto&& kv) { return kv.first == source; });
+        if (it != channelMap.end()) {
+            return it->second;
+        }
+        return std::nullopt;
+    }
+
+    static constexpr std::optional<ChannelType> convertToChannel(std::size_t channelIndex) {
+        static constexpr std::array<std::pair<std::size_t, ChannelType>, 5> channelMap{{//
+            {0UZ, PS3000A_CHANNEL_A}, {1UZ, PS3000A_CHANNEL_B}, {2UZ, PS3000A_CHANNEL_C}, {3UZ, PS3000A_CHANNEL_D}, {4UZ, PS3000A_EXTERNAL}}};
+
+        const auto it = std::ranges::find_if(channelMap, [channelIndex](auto&& kv) { return kv.first == channelIndex; });
+        if (it != channelMap.end()) {
+            return it->second;
+        }
+        return std::nullopt;
+    }
+
+    static constexpr CouplingType convertToCoupling(Coupling coupling) {
+        if (coupling == Coupling::AC) {
+            return PS3000A_AC;
+        }
+        if (coupling == Coupling::DC) {
+            return PS3000A_DC;
+        }
+        throw std::runtime_error(fmt::format("Unsupported coupling mode: {}", static_cast<int>(coupling)));
+    }
+
+    static constexpr RangeType convertToRange(float range) {
+        static constexpr std::array<std::pair<float, RangeType>, 12> rangeMap = {{                      //
+            {0.01f, PS3000A_10MV}, {0.02f, PS3000A_20MV}, {0.05f, PS3000A_50MV}, {0.1f, PS3000A_100MV}, //
+            {0.2f, PS3000A_200MV}, {0.5f, PS3000A_500MV}, {1.0f, PS3000A_1V}, {2.0f, PS3000A_2V},       //
+            {5.0f, PS3000A_5V}, {10.0f, PS3000A_10V}, {20.0f, PS3000A_20V}, {50.0f, PS3000A_50V}}};
+
+        const auto exactIt = std::ranges::find_if(rangeMap, [range](auto& kv) { return std::fabs(kv.first - range) < 1e-6f; });
+        if (exactIt != rangeMap.end()) {
+            return exactIt->second;
+        }
+        // if no exact match -> find the next higher range
+        const auto upperIt = std::ranges::find_if(rangeMap, [range](const auto& kv) { return kv.first > range; });
+        return upperIt != rangeMap.end() ? upperIt->second : PS3000A_50V;
+    }
+
+    constexpr ThresholdDirectionType convertToThresholdDirection(TriggerDirection direction) {
+        using enum TriggerDirection;
+        switch (direction) {
+        case Rising: return PS3000A_RISING;
+        case Falling: return PS3000A_FALLING;
+        case Low: return PS3000A_BELOW;
+        case High: return PS3000A_ABOVE;
+        default: throw std::runtime_error(fmt::format("Unsupported trigger direction: {}", static_cast<int>(direction)));
+        }
+    };
+
+    constexpr float uncertainty() {
+        // https://www.picotech.com/oscilloscope/3000/picoscope-3000-oscilloscope-specifications
+        return 0.0000160f;
+    }
+
+    PICO_STATUS
+    setDataBuffer(int16_t handle, ChannelType channel, int16_t* buffer, int32_t bufferLth, uint32_t segmentIndex, RatioModeType mode) { return ps3000aSetDataBuffer(handle, channel, buffer, bufferLth, segmentIndex, mode); }
+
+    PICO_STATUS
+    getTimebase2(int16_t handle, uint32_t timebase, int32_t noSamples, float* timeIntervalNanoseconds, int32_t* maxSamples, uint32_t segmentIndex) { return ps3000aGetTimebase2(handle, timebase, noSamples, timeIntervalNanoseconds, /* oversample */ 0, maxSamples, segmentIndex); }
+
+    PICO_STATUS
+    openUnit(const std::string& serial_number) {
+        // take any if serial number is not provided (useful for testing purposes)
+        if (serial_number.empty()) {
+            return ps3000aOpenUnit(&(this->_handle), nullptr);
+        } else {
+            return ps3000aOpenUnit(&(this->_handle), const_cast<int8_t*>(reinterpret_cast<const int8_t*>(serial_number.data())));
+        }
+    }
+
+    PICO_STATUS
+    closeUnit(int16_t handle) { return ps3000aCloseUnit(handle); }
+
+    PICO_STATUS
+    changePowerSource(int16_t handle, PICO_STATUS powerstate) { return ps3000aChangePowerSource(handle, powerstate); }
+
+    PICO_STATUS
+    maximumValue(int16_t handle, int16_t* value) { return ps3000aMaximumValue(handle, value); }
+
+    PICO_STATUS
+    memorySegments(int16_t handle, uint32_t nSegments, int32_t* nMaxSamples) { return ps3000aMemorySegments(handle, nSegments, nMaxSamples); }
+
+    PICO_STATUS
+    setNoOfCaptures(int16_t handle, uint32_t nCaptures) { return ps3000aSetNoOfCaptures(handle, nCaptures); }
+
+    PICO_STATUS
+    getNoOfCaptures(int16_t handle, uint32_t* nCaptures) const { return ps3000aGetNoOfCaptures(handle, nCaptures); }
+
+    PICO_STATUS
+    getNoOfProcessedCaptures(int16_t handle, uint32_t* nProcessedCaptures) const { return ps3000aGetNoOfProcessedCaptures(handle, nProcessedCaptures); }
+
+    PICO_STATUS
+    setChannel(int16_t handle, ChannelType channel, int16_t enabled, CouplingType type, ChannelRangeType range, float analogOffset) { return ps3000aSetChannel(handle, channel, enabled, type, range, analogOffset); }
+
+    int maxChannel() { return PS3000A_MAX_CHANNELS; }
+
+    int extTriggerMaxValue() { return PS3000A_EXT_MAX_VALUE; }
+
+    int extTriggerMinValue() { return PS3000A_EXT_MIN_VALUE; }
+
+    float extTriggerMaxValueVoltage() { return 5.f; }
+
+    float extTriggerMinValueVoltage() { return -5.f; }
+
+    CouplingType analogCoupling() { return PS3000A_AC; }
+
+    TriggerStateType conditionDontCare() { return PS3000A_CONDITION_DONT_CARE; }
+
+    ConditionsInfoType conditionsInfoClear() { return PS3000A_CLEAR; }
+
+    ConditionsInfoType conditionsInfoAdd() { return PS3000A_ADD; }
+
+    PICO_STATUS
+    setSimpleTrigger(int16_t handle, int16_t enable, ChannelType source, int16_t threshold, ThresholdDirectionType direction, uint32_t delay, int16_t autoTriggerMs) { return ps3000aSetSimpleTrigger(handle, enable, source, threshold, direction, delay, autoTriggerMs); }
+
+    PS3000A_TRIGGER_CONDITIONS
+    convertToTriggerConditions(ConditionType* conditions, int16_t nConditions) {
+        PS3000A_TRIGGER_CONDITIONS result{};
+        for (int16_t i = 0; i < nConditions; ++i) {
+            const ConditionType& cond = conditions[i];
+            if (cond.source == PS3000A_CHANNEL_A) {
+                result.channelA = cond.condition;
+            } else if (cond.source == PS3000A_CHANNEL_B) {
+                result.channelB = cond.condition;
+            } else if (cond.source == PS3000A_CHANNEL_C) {
+                result.channelC = cond.condition;
+            } else if (cond.source == PS3000A_CHANNEL_D) {
+                result.channelD = cond.condition;
+            }
+        }
+        return result;
+    }
+
+    PICO_STATUS
+    setTriggerChannelConditions(int16_t handle, ConditionType* conditions, int16_t nConditions, ConditionsInfoType) {
+        PS3000A_TRIGGER_CONDITIONS conds = convertToTriggerConditions(conditions, nConditions);
+        return ps3000aSetTriggerChannelConditions(handle, &conds, 1);
+    }
+
+    PICO_STATUS
+    driverStop(int16_t handle) { return ps3000aStop(handle); }
+
+    PICO_STATUS
+    runBlock(int16_t handle, int32_t noOfPreTriggerSamples, int32_t noOfPostTriggerSamples, uint32_t timebase, int32_t* timeIndisposed, uint32_t segmentIndex, BlockReadyType ready, void* param) { return ps3000aRunBlock(handle, noOfPreTriggerSamples, noOfPostTriggerSamples, timebase, /* oversample, not used*/ 0, timeIndisposed, segmentIndex, ready, param); }
+
+    PICO_STATUS
+    runStreaming(int16_t handle, uint32_t* sampleInterval, TimeUnitsType timeUnits, uint32_t maxPreTriggerSamples, uint32_t maxPostTriggerSamples, int16_t autoStop, uint32_t downSampleRatio, RatioModeType downSampleRatioMode, uint32_t overviewBufferSize) { return ps3000aRunStreaming(handle, sampleInterval, timeUnits, maxPreTriggerSamples, maxPostTriggerSamples, autoStop, downSampleRatio, downSampleRatioMode, overviewBufferSize); }
+
+    RatioModeType ratioNone() { return PS3000A_RATIO_MODE_NONE; }
+
+    PICO_STATUS
+    getStreamingLatestValues(int16_t handle, StreamingReadyType ready, void* param) { return ps3000aGetStreamingLatestValues(handle, ready, param); }
+
+    PICO_STATUS
+    getValues(int16_t handle, uint32_t startIndex, uint32_t* noOfSamples, uint32_t downSampleRatio, RatioModeType downSampleRatioMode, uint32_t segmentIndex, int16_t* overflow) { return ps3000aGetValues(handle, startIndex, noOfSamples, downSampleRatio, downSampleRatioMode, segmentIndex, overflow); }
+
+    PICO_STATUS
+    getUnitInfo(int16_t handle, int8_t* string, int16_t stringLength, int16_t* requiredSize, PICO_INFO info) const { return ps3000aGetUnitInfo(handle, string, stringLength, requiredSize, info); }
+
+    PICO_STATUS
+    getDeviceResolution(int16_t, DeviceResolutionType*) const { return PICO_NOT_SUPPORTED_BY_THIS_DEVICE; }
+
+    // Digital picoscope inputs
+
+    [[nodiscard]] Error setDigitalPorts() {
+        for (std::size_t i = 0; i < 2; i++) {
+            const PS3000A_DIGITAL_PORT channelId = i == 0 ? PS3000A_DIGITAL_PORT0 : PS3000A_DIGITAL_PORT1;
+            const PICO_STATUS          status    = ps3000aSetDigitalPort(this->_handle, channelId, true, this->digital_port_threshold);
+
+            if (status != PICO_OK) {
+                fmt::println(std::cerr, "setDigitalPorts (chan {}): {}", magic_enum::enum_name(channelId), detail::getErrorMessage(status));
+                return {status};
+            }
+        }
+        return {};
+    }
+
+    [[nodiscard]] Error setDigitalBuffers(size_t nSamples, uint32_t segmentIndex) {
+        for (std::size_t i = 0; i < 2; i++) {
+            const auto channelId = i == 0 ? PS3000A_DIGITAL_PORT0 : PS3000A_DIGITAL_PORT1;
+            _digitalBuffers[i].resize(std::max(nSamples, _digitalBuffers[i].size()));
+            const PICO_STATUS status = ps3000aSetDataBuffer(this->_handle, static_cast<PS3000A_CHANNEL>(static_cast<int>(channelId)), _digitalBuffers[i].data(), static_cast<int32_t>(nSamples), segmentIndex, ratioNone());
+
+            if (status != PICO_OK) {
+                fmt::println(std::cerr, "setDigitalBuffers (chan {}): {}", magic_enum::enum_name(channelId), detail::getErrorMessage(status));
+                return {status};
+            }
+        }
+        return {};
+    }
+
+    void copyDigitalBuffersToOutput(std::span<std::uint16_t> output, std::size_t nSamples) {
+        assert(output.size() >= nSamples);
+        for (std::size_t i = 0; i < nSamples; i++) {
+            uint16_t value = 0x00FF & static_cast<uint16_t>(_digitalBuffers[1][i]);
+            value <<= 8;
+            value |= 0x00FF & static_cast<uint16_t>(_digitalBuffers[0][i]);
+            if (this->digital_port_invert_output) {
+                value = ~value;
+            }
+            output[i] = value;
+        }
+    }
+};
+
+} // namespace fair::picoscope
+
+#endif

--- a/blocklib/picoscope/Picoscope4000a.hpp
+++ b/blocklib/picoscope/Picoscope4000a.hpp
@@ -203,14 +203,13 @@ struct Picoscope4000a : public fair::picoscope::Picoscope<T, Picoscope4000a<T>> 
 
     ConditionsInfoType conditionsInfoClear() { return PS4000A_CLEAR; }
 
+    ConditionsInfoType conditionsInfoAdd() { return PS4000A_ADD; }
+
     PICO_STATUS
     setSimpleTrigger(int16_t handle, int16_t enable, ChannelType source, int16_t threshold, ThresholdDirectionType direction, uint32_t delay, int16_t autoTriggerMs) { return ps4000aSetSimpleTrigger(handle, enable, source, threshold, direction, delay, autoTriggerMs); }
 
     PICO_STATUS
     setTriggerChannelConditions(int16_t handle, ConditionType* conditions, int16_t nConditions, ConditionsInfoType info) { return ps4000aSetTriggerChannelConditions(handle, conditions, nConditions, info); }
-
-    PICO_STATUS
-    setAutoTriggerMicroSeconds(int16_t handle, uint64_t autoTriggerMicroseconds) { return PICO_NOT_SUPPORTED_BY_THIS_DEVICE; }
 
     PICO_STATUS
     driverStop(int16_t handle) { return ps4000aStop(handle); }

--- a/blocklib/picoscope/Picoscope4000a.hpp
+++ b/blocklib/picoscope/Picoscope4000a.hpp
@@ -189,7 +189,13 @@ struct Picoscope4000a : public fair::picoscope::Picoscope<T, Picoscope4000a<T>> 
 
     int maxChannel() { return PS4000A_MAX_CHANNELS; }
 
-    int maxADCCount() { return PS4000A_EXT_MAX_VALUE; }
+    int extTriggerMaxValue() { return PS4000A_EXT_MAX_VALUE; }
+
+    int extTriggerMinValue() { return PS4000A_EXT_MIN_VALUE; }
+
+    float extTriggerMaxValueVoltage() { return 5.f; }
+
+    float extTriggerMinValueVoltage() { return -5.f; }
 
     CouplingType analogCoupling() { return PS4000A_AC; }
 
@@ -228,6 +234,11 @@ struct Picoscope4000a : public fair::picoscope::Picoscope<T, Picoscope4000a<T>> 
 
     PICO_STATUS
     getDeviceResolution(int16_t handle, DeviceResolutionType* deviceResolution) const { return ps4000aGetDeviceResolution(handle, deviceResolution); }
+
+    // Digital picoscope inputs, not supported by picoscope 4000A
+    [[nodiscard]] Error setDigitalPorts() { return {}; }
+    [[nodiscard]] Error setDigitalBuffers(size_t, uint32_t) { return {}; }
+    void                copyDigitalBuffersToOutput(std::span<std::uint16_t>, std::size_t) {}
 };
 
 } // namespace fair::picoscope

--- a/blocklib/picoscope/Picoscope4000a.hpp
+++ b/blocklib/picoscope/Picoscope4000a.hpp
@@ -94,6 +94,18 @@ public:
         return std::nullopt;
     }
 
+    static constexpr std::optional<ChannelType> convertToChannel(std::size_t channelIndex) {
+        static constexpr std::array<std::pair<std::size_t, ChannelType>, 9> channelMap{{                            //
+            {0UZ, PS4000A_CHANNEL_A}, {1UZ, PS4000A_CHANNEL_B}, {2UZ, PS4000A_CHANNEL_C}, {3UZ, PS4000A_CHANNEL_D}, //
+            {4UZ, PS4000A_CHANNEL_E}, {5UZ, PS4000A_CHANNEL_F}, {6UZ, PS4000A_CHANNEL_G}, {7UZ, PS4000A_CHANNEL_H}, {8UZ, PS4000A_EXTERNAL}}};
+
+        const auto it = std::ranges::find_if(channelMap, [channelIndex](auto&& kv) { return kv.first == channelIndex; });
+        if (it != channelMap.end()) {
+            return it->second;
+        }
+        return std::nullopt;
+    }
+
     static constexpr CouplingType convertToCoupling(Coupling coupling) {
         if (coupling == Coupling::AC_1M) {
             return PS4000A_AC;
@@ -190,6 +202,9 @@ public:
 
     PICO_STATUS
     setTriggerChannelConditions(int16_t handle, ConditionType* conditions, int16_t nConditions, ConditionsInfoType info) { return ps4000aSetTriggerChannelConditions(handle, conditions, nConditions, info); }
+
+    PICO_STATUS
+    setAutoTriggerMicroSeconds(int16_t handle, uint64_t autoTriggerMicroseconds) { return PICO_NOT_SUPPORTED_BY_THIS_DEVICE; }
 
     PICO_STATUS
     driverStop(int16_t handle) { return ps4000aStop(handle); }

--- a/blocklib/picoscope/Picoscope4000a.hpp
+++ b/blocklib/picoscope/Picoscope4000a.hpp
@@ -167,6 +167,12 @@ public:
     setNoOfCaptures(int16_t handle, uint32_t nCaptures) { return ps4000aSetNoOfCaptures(handle, nCaptures); }
 
     PICO_STATUS
+    getNoOfCaptures(int16_t handle, uint32_t* nCaptures) const { return ps4000aGetNoOfCaptures(handle, nCaptures); }
+
+    PICO_STATUS
+    getNoOfProcessedCaptures(int16_t handle, uint32_t* nProcessedCaptures) const { return ps4000aGetNoOfProcessedCaptures(handle, nProcessedCaptures); }
+
+    PICO_STATUS
     setChannel(int16_t handle, ChannelType channel, int16_t enabled, CouplingType type, ChannelRangeType range, float analogOffset) { return ps4000aSetChannel(handle, channel, enabled, type, range, analogOffset); }
 
     int maxChannel() { return PS4000A_MAX_CHANNELS; }

--- a/blocklib/picoscope/Picoscope5000a.hpp
+++ b/blocklib/picoscope/Picoscope5000a.hpp
@@ -167,6 +167,17 @@ public:
         return std::nullopt;
     }
 
+    static constexpr std::optional<ChannelType> convertToChannel(std::size_t channelIndex) {
+        static constexpr std::array<std::pair<std::size_t, ChannelType>, 9> channelMap{{//
+            {0UZ, PS5000A_CHANNEL_A}, {1UZ, PS5000A_CHANNEL_B}, {2UZ, PS5000A_CHANNEL_C}, {3UZ, PS5000A_CHANNEL_D}, {4UZ, PS5000A_EXTERNAL}}};
+
+        const auto it = std::ranges::find_if(channelMap, [channelIndex](auto&& kv) { return kv.first == channelIndex; });
+        if (it != channelMap.end()) {
+            return it->second;
+        }
+        return std::nullopt;
+    }
+
     static constexpr CouplingType convertToCoupling(Coupling coupling) {
         if (coupling == Coupling::AC_1M) {
             return PS5000A_AC;
@@ -259,6 +270,9 @@ public:
 
     PICO_STATUS
     setSimpleTrigger(int16_t handle, int16_t enable, ChannelType source, int16_t threshold, ThresholdDirectionType direction, uint32_t delay, int16_t autoTriggerMs) { return ps5000aSetSimpleTrigger(handle, enable, source, threshold, direction, delay, autoTriggerMs); }
+
+    PICO_STATUS
+    setAutoTriggerMicroSeconds(int16_t handle, uint64_t autoTriggerMicroseconds) { return ps5000aSetAutoTriggerMicroSeconds(handle, autoTriggerMicroseconds); }
 
     PS5000A_TRIGGER_CONDITIONS
     conditionsShim(ConditionType* condition, int16_t nConditions) {

--- a/blocklib/picoscope/Picoscope5000a.hpp
+++ b/blocklib/picoscope/Picoscope5000a.hpp
@@ -239,6 +239,12 @@ public:
     setNoOfCaptures(int16_t handle, uint32_t nCaptures) { return ps5000aSetNoOfCaptures(handle, nCaptures); }
 
     PICO_STATUS
+    getNoOfCaptures(int16_t handle, uint32_t* nCaptures) const { return ps5000aGetNoOfCaptures(handle, nCaptures); }
+
+    PICO_STATUS
+    getNoOfProcessedCaptures(int16_t handle, uint32_t* nProcessedCaptures) const { return ps5000aGetNoOfProcessedCaptures(handle, nProcessedCaptures); }
+
+    PICO_STATUS
     setChannel(int16_t handle, ChannelType channel, int16_t enabled, CouplingType type, ChannelRangeType range, float analogOffset) { return ps5000aSetChannel(handle, channel, enabled, type, range, analogOffset); }
 
     int maxChannel() { return PS5000A_MAX_CHANNELS; }

--- a/blocklib/picoscope/test/CMakeLists.txt
+++ b/blocklib/picoscope/test/CMakeLists.txt
@@ -7,7 +7,7 @@ function(add_ut_test_tool TEST_NAME)
     ${TEST_NAME}
     PRIVATE ${CMAKE_BINARY_DIR}/include ${CMAKE_CURRENT_BINARY_DIR}
             ${CMAKE_CURRENT_SOURCE_DIR})
-  target_link_libraries(${TEST_NAME} PRIVATE gnuradio-core gr-testing
+  target_link_libraries(${TEST_NAME} PRIVATE gnuradio-core gr-testing gr-basic
                                              fair-picoscope fair-helpers ut)
 endfunction()
 

--- a/blocklib/picoscope/test/qa_Picoscope.cc
+++ b/blocklib/picoscope/test/qa_Picoscope.cc
@@ -12,54 +12,76 @@ using namespace std::string_literals;
 namespace fair::picoscope::test {
 
 // Replace with your connected Picoscope device
-template<typename T, AcquisitionMode aMode>
-using PicoscopeT = Picoscope4000a<T, aMode>;
-
-static_assert(gr::HasProcessBulkFunction<PicoscopeT<float, AcquisitionMode::Streaming>>);
-static_assert(gr::HasProcessBulkFunction<PicoscopeT<float, AcquisitionMode::RapidBlock>>);
-
 template<typename T>
-void testRapidBlockBasic(std::size_t nrCaptures) {
+using PicoscopeT = Picoscope5000a<T>;
+
+static_assert(gr::HasProcessBulkFunction<PicoscopeT<float>>);
+static_assert(gr::HasProcessBulkFunction<PicoscopeT<float>>);
+
+template<gr::DataSetLike T>
+void testRapidBlockBasic(std::size_t nCaptures) {
     using namespace boost::ut;
     using namespace gr;
     using namespace fair::helpers;
     using namespace fair::picoscope;
 
-    fmt::println("testRapidBlockBasic - {}", gr::meta::type_name<T>());
+    fmt::println("testRapidBlockBasic({}) - {}", nCaptures, gr::meta::type_name<T>());
 
-    constexpr float      sampleRate   = 1234567.f;
-    constexpr gr::Size_t kPreSamples  = 33;
-    constexpr gr::Size_t kPostSamples = 1000;
-    const gr::Size_t     totalSamples = nrCaptures * (kPreSamples + kPostSamples);
+    constexpr float      sampleRate       = 1234567.f;
+    constexpr float      actualSampleRate = 1250000.f; // for Picoscope4000a
+    constexpr gr::Size_t preSamples       = 33;
+    constexpr gr::Size_t postSamples      = 1000;
+    const gr::Size_t     totalSamples     = preSamples + postSamples;
 
     Graph flowGraph;
-    auto& ps = flowGraph.emplaceBlock<PicoscopeT<T, AcquisitionMode::RapidBlock>>({{{"sample_rate", sampleRate},                                   //
-        {"pre_samples", kPreSamples}, {"post_samples", kPostSamples}, {"acquisition_mode", "RapidBlock"}, {"rapid_block_nr_captures", nrCaptures}, //
-        {"auto_arm", true}, {"trigger_once", true}, {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}},   //
+    auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{{"disconnect_on_done", true}, {"sample_rate", sampleRate}, {"pre_samples", preSamples}, {"post_samples", postSamples}, {"n_captures", nCaptures}, //
+        {"auto_arm", true}, {"trigger_once", true}, {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}},                                                         //
         {"channel_couplings", std::vector<std::string>{"AC_1M"}}}});
 
-    auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-    auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", false}}});
+    auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", false}}});
     auto& sinkC = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
     auto& sinkD = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-    auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-    auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-    auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-    auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
 
     expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 0>(ps).template to<"in">(sinkA)));
     expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 1>(ps).template to<"in">(sinkB)));
     expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 2>(ps).template to<"in">(sinkC)));
     expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 3>(ps).template to<"in">(sinkD)));
-    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
-    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
-    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 6>(ps).template to<"in">(sinkG)));
-    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 7>(ps).template to<"in">(sinkH)));
+
+    if constexpr (std::is_same_v<Picoscope4000a<T>, PicoscopeT<T>>) {
+        auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 6>(ps).template to<"in">(sinkG)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 7>(ps).template to<"in">(sinkH)));
+    }
 
     scheduler::Simple sched{std::move(flowGraph)};
     expect(sched.runAndWait().has_value());
 
-    expect(eq(sinkA._nSamplesProduced, totalSamples));
+    if constexpr (std::is_same_v<Picoscope4000a<T>, PicoscopeT<T>>) {
+        expect(eq(ps._actualSampleRate, actualSampleRate));
+    }
+
+    expect(eq(sinkA._nSamplesProduced, nCaptures)); // number of DataSets
+    expect(eq(sinkA._samples.size(), nCaptures));   // number of DataSets
+    if (sinkA._samples.size() >= nCaptures) {
+        for (std::size_t iC = 0; iC < sinkA._samples.size(); iC++) {
+            expect(eq(sinkA._samples[iC].signal_values.size(), totalSamples));
+        }
+    }
+
+    expect(eq(sinkB._nSamplesProduced, nCaptures)); // empty DataSets are published if channel is not active, TODO: this logic can be changed later
+    expect(eq(sinkB._samples.size(), nCaptures));
+    if (sinkB._samples.size() >= nCaptures) {
+        for (std::size_t iC = 0; iC < sinkB._samples.size(); iC++) {
+            expect(eq(sinkB._samples[iC].signal_values.size(), 0UZ));
+        }
+    }
 }
 
 template<typename T>
@@ -74,11 +96,11 @@ void testStreamingBasics() {
 
     fmt::println("testStreamingBasics - {}", gr::meta::type_name<T>());
 
-    constexpr float kSampleRate = 83000.f;
-    constexpr auto  kDuration   = 2s;
+    constexpr float sampleRate   = 83000.f;
+    constexpr auto  testDuration = 2s;
 
-    auto& ps = flowGraph.emplaceBlock<PicoscopeT<T, AcquisitionMode::Streaming>>({{{"sample_rate", kSampleRate},                                                         //
-        {"acquisition_mode", "Streaming"}, {"streaming_mode_poll_rate", 0.00001f}, {"auto_arm", true}, {"channel_ids", std::vector<std::string>{"A"}},                   //
+    auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{{"sample_rate", sampleRate},                                                                                      //
+        {"streaming_mode_poll_rate", 0.00001f}, {"auto_arm", true}, {"channel_ids", std::vector<std::string>{"A"}},                                                      //
         {"signal_names", std::vector<std::string>{"Test signal"}}, {"signal_units", std::vector<std::string>{"Test unit"}}, {"channel_ranges", std::vector<float>{5.f}}, //
         {"channel_couplings", std::vector<std::string>{"AC_1M"}}}});
 
@@ -87,20 +109,24 @@ void testStreamingBasics() {
     auto& sinkB      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
     auto& sinkC      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
     auto& sinkD      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-    auto& sinkE      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-    auto& sinkF      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-    auto& sinkG      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-    auto& sinkH      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
 
     expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 0>(ps).template to<"in">(tagMonitor)));
     expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out">(tagMonitor).template to<"in">(sinkA)));
     expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 1>(ps).template to<"in">(sinkB)));
     expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 2>(ps).template to<"in">(sinkC)));
     expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 3>(ps).template to<"in">(sinkD)));
-    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
-    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
-    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 6>(ps).template to<"in">(sinkG)));
-    expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 7>(ps).template to<"in">(sinkH)));
+
+    if constexpr (std::is_same_v<Picoscope4000a<T>, PicoscopeT<T>>) {
+        auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 6>(ps).template to<"in">(sinkG)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 7>(ps).template to<"in">(sinkH)));
+    }
 
     // Explicitly start unit because it takes quite some time
     expect(nothrow([&ps] { ps.start(); }));
@@ -108,12 +134,12 @@ void testStreamingBasics() {
     scheduler::Simple<scheduler::ExecutionPolicy::multiThreaded> sched{std::move(flowGraph)};
     expect(sched.changeStateTo(lifecycle::State::INITIALISED).has_value());
     expect(sched.changeStateTo(lifecycle::State::RUNNING).has_value());
-    std::this_thread::sleep_for(kDuration);
+    std::this_thread::sleep_for(testDuration);
     expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value());
 
-    const auto measuredRate = static_cast<double>(sinkA._nSamplesProduced) / duration<double>(kDuration).count();
-    fmt::println("Produced in worker: {}", ps.producedWorker());
-    fmt::println("Configured rate: {}, Measured rate: {} ({:.2f}%), Duration: {} ms", kSampleRate, static_cast<std::size_t>(measuredRate), measuredRate / static_cast<double>(kSampleRate) * 100., duration_cast<milliseconds>(kDuration).count());
+    const auto measuredRate = static_cast<double>(sinkA._nSamplesProduced) / duration<double>(testDuration).count();
+    fmt::println("Produced in worker: {}", ps._nSamplesPublished);
+    fmt::println("Configured rate: {}, Measured rate: {} ({:.2f}%), Duration: {} ms", sampleRate, static_cast<std::size_t>(measuredRate), measuredRate / static_cast<double>(sampleRate) * 100., duration_cast<milliseconds>(testDuration).count());
     fmt::println("Total samples: {}", sinkA._nSamplesProduced);
     fmt::println("Total tags: {}", tagMonitor._tags.size());
 
@@ -123,7 +149,7 @@ void testStreamingBasics() {
     if (tagMonitor._tags.size() == 1UZ) {
         const auto& tag = tagMonitor._tags[0];
         expect(eq(tag.index, int64_t{0}));
-        expect(eq(std::get<float>(tag.at(std::string(tag::SAMPLE_RATE.shortKey()))), kSampleRate));
+        expect(eq(std::get<float>(tag.at(std::string(tag::SAMPLE_RATE.shortKey()))), sampleRate));
         expect(eq(std::get<std::string>(tag.at(std::string(tag::SIGNAL_NAME.shortKey()))), "Test signal"s));
         expect(eq(std::get<std::string>(tag.at(std::string(tag::SIGNAL_UNIT.shortKey()))), "Test unit"s));
         expect(eq(std::get<float>(tag.at(std::string(tag::SIGNAL_MIN.shortKey()))), 0.f));
@@ -139,14 +165,14 @@ const boost::ut::suite PicoscopeTests = [] {
 
     "open and close"_test = [] {
         Graph flowGraph;
-        auto& ps = flowGraph.emplaceBlock<PicoscopeT<float, AcquisitionMode::RapidBlock>>();
+        auto& ps = flowGraph.emplaceBlock<PicoscopeT<DataSet<float>>>();
 
         // this takes time, so we do it a few times only
         for (auto i = 0; i < 3; i++) {
             expect(nothrow([&ps] { ps.initialize(); }));
             expect(neq(ps.driverVersion(), std::string()));
             expect(neq(ps.hardwareVersion(), std::string()));
-            expect(nothrow([&ps] { ps.close(); })) << "doesn't throw";
+            expect(nothrow([&ps] { ps.stop(); })) << "doesn't throw";
         }
     };
 
@@ -157,85 +183,126 @@ const boost::ut::suite PicoscopeTests = [] {
     };
 
     "rapid block basics"_test = [] {
-        testRapidBlockBasic<int16_t>(1);
-        testRapidBlockBasic<float>(1);
-        testRapidBlockBasic<gr::UncertainValue<float>>(1);
+        testRapidBlockBasic<gr::DataSet<int16_t>>(1);
+        testRapidBlockBasic<gr::DataSet<float>>(1);
+        testRapidBlockBasic<gr::DataSet<gr::UncertainValue<float>>>(1);
     };
 
-    "rapid block multiple captures"_test = [] { testRapidBlockBasic<float>(3); };
+    "rapid block multiple captures"_test = [] { testRapidBlockBasic<DataSet<float>>(3); };
 
-    "rapid block 4 channels"_test = [] {
-        constexpr gr::Size_t kPreSamples   = 33;
-        constexpr gr::Size_t kPostSamples  = 1000;
-        constexpr gr::Size_t kNrCaptures   = 2;
-        constexpr gr::Size_t kTotalSamples = kNrCaptures * (kPreSamples + kPostSamples);
+    "rapid block 3 channels"_test = [] {
+        constexpr gr::Size_t preSamples   = 33;
+        constexpr gr::Size_t postSamples  = 1000;
+        constexpr gr::Size_t nCaptures    = 5;
+        constexpr gr::Size_t totalSamples = preSamples + postSamples;
+        using T                           = DataSet<float>;
 
         Graph flowGraph;
-        auto& ps = flowGraph.emplaceBlock<PicoscopeT<float, AcquisitionMode::RapidBlock>>({{{"sample_rate", 10000.f},                                   //
-            {"pre_samples", kPreSamples}, {"post_samples", kPostSamples}, {"acquisition_mode", "RapidBlock"}, {"rapid_block_nr_captures", kNrCaptures}, //
-            {"auto_arm", true}, {"trigger_once", true}, {"channel_ids", std::vector<std::string>{"A", "B", "C", "D"}},                                  //
-            {"channel_ranges", std::vector<float>{{5.f, 5.f, 5.f, 5.f}}}, {"channel_couplings", std::vector<std::string>{"AC_1M", "AC_1M", "AC_1M", "AC_1M"}}}});
+        auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{{"sample_rate", 10000.f},                              //
+            {"pre_samples", preSamples}, {"post_samples", postSamples}, {"n_captures", nCaptures},                //
+            {"auto_arm", true}, {"trigger_once", true}, {"channel_ids", std::vector<std::string>{"A", "B", "C"}}, //
+            {"channel_ranges", std::vector<float>{{5.f, 5.f, 5.f}}}, {"channel_couplings", std::vector<std::string>{"AC_1M", "AC_1M", "AC_1M"}}}});
 
-        auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkC = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkD = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", false}}});
+        auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", false}}});
+        auto& sinkC = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", false}}});
+        auto& sinkD = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", false}}});
 
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 0>(ps).template to<"in">(sinkA)));
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 1>(ps).template to<"in">(sinkB)));
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 2>(ps).template to<"in">(sinkC)));
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 3>(ps).template to<"in">(sinkD)));
-        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
-        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
-        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 6>(ps).template to<"in">(sinkG)));
-        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 7>(ps).template to<"in">(sinkH)));
+
+        if constexpr (std::is_same_v<Picoscope4000a<T>, PicoscopeT<T>>) {
+            auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+            auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+            auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+            auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+
+            expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
+            expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
+            expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 6>(ps).template to<"in">(sinkG)));
+            expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 7>(ps).template to<"in">(sinkH)));
+        }
 
         scheduler::Simple sched{std::move(flowGraph)};
         sched.runAndWait();
 
-        expect(eq(sinkA._nSamplesProduced, kTotalSamples));
-        expect(eq(sinkB._nSamplesProduced, kTotalSamples));
-        expect(eq(sinkC._nSamplesProduced, kTotalSamples));
-        expect(eq(sinkD._nSamplesProduced, kTotalSamples));
+        expect(eq(sinkA._nSamplesProduced, nCaptures));
+        expect(eq(sinkB._nSamplesProduced, nCaptures));
+        expect(eq(sinkC._nSamplesProduced, nCaptures));
+        expect(eq(sinkD._nSamplesProduced, nCaptures)); // empty DataSets
+
+        const bool allSameSize = sinkA._samples.size() == sinkB._samples.size() && sinkB._samples.size() == sinkC._samples.size() && sinkC._samples.size() == sinkD._samples.size();
+        expect(allSameSize);
+
+        if (sinkA._samples.size() >= nCaptures) {
+            for (std::size_t iC = 0; iC < sinkA._samples.size(); iC++) {
+                expect(eq(sinkA._samples[iC].signal_values.size(), totalSamples));
+                expect(eq(sinkB._samples[iC].signal_values.size(), totalSamples));
+                expect(eq(sinkC._samples[iC].signal_values.size(), totalSamples));
+                expect(eq(sinkD._samples[iC].signal_values.size(), 0UZ));
+            }
+        }
     };
 
     "rapid block continuous"_test = [] {
         using namespace std::chrono_literals;
+
+        using T = DataSet<float>;
+
+        constexpr float      sampleRate   = 1000.f;
+        constexpr gr::Size_t postSamples  = 100;
+        constexpr gr::Size_t preSamples   = 15;
+        constexpr gr::Size_t totalSamples = postSamples + preSamples;
+        constexpr auto       testDuration = 3s;
+
+        const double      timePerDataset   = static_cast<double>(totalSamples) / sampleRate;
+        const double      testDurationSecs = std::chrono::duration<double>(testDuration).count();
+        const std::size_t maxDatasets      = static_cast<size_t>(std::floor(testDurationSecs / timePerDataset));
+        const std::size_t minDatasets      = 2UZ;
+
         Graph flowGraph;
-        auto& ps = flowGraph.emplaceBlock<PicoscopeT<float, AcquisitionMode::RapidBlock>>({{{"sample_rate", 10000.f},                               //
-            {"post_samples", gr::Size_t{1000}}, {"acquisition_mode", "RapidBlock"}, {"rapid_block_nr_captures", gr::Size_t{1}}, {"auto_arm", true}, //
+        auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{{"sample_rate", sampleRate}, {"pre_samples", preSamples}, {"post_samples", postSamples}, {"n_captures", gr::Size_t{1}}, {"auto_arm", true}, //
             {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}}, {"channel_couplings", std::vector<std::string>{"AC_1M"}}}});
 
-        auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkC = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkD = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", false}}});
+        auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkC = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkD = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
 
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 0>(ps).to<"in">(sinkA)));
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 1>(ps).template to<"in">(sinkB)));
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 2>(ps).template to<"in">(sinkC)));
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 3>(ps).template to<"in">(sinkD)));
-        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
-        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
-        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 6>(ps).template to<"in">(sinkG)));
-        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 7>(ps).template to<"in">(sinkH)));
 
+        if constexpr (std::is_same_v<Picoscope4000a<T>, PicoscopeT<T>>) {
+            auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+            auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+            auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+            auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+
+            expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
+            expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
+            expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 6>(ps).template to<"in">(sinkG)));
+            expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 7>(ps).template to<"in">(sinkH)));
+        }
+
+        // Explicitly start unit because it takes quite some time
+        expect(nothrow([&ps] { ps.start(); }));
         scheduler::Simple<scheduler::ExecutionPolicy::multiThreaded> sched{std::move(flowGraph)};
         expect(sched.changeStateTo(lifecycle::State::INITIALISED).has_value());
         expect(sched.changeStateTo(lifecycle::State::RUNNING).has_value());
-        std::this_thread::sleep_for(3s);
+        std::this_thread::sleep_for(testDuration);
         expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value());
 
-        expect(ge(sinkA._nSamplesProduced, std::size_t{2000}));
-        expect(le(sinkA._nSamplesProduced, std::size_t{10000}));
+        fmt::println("rapid block continuous: producedDatasets:{}, valid range: [{}, {}]", sinkA._nSamplesProduced, minDatasets, maxDatasets);
+        expect(ge(sinkA._nSamplesProduced, minDatasets));
+        expect(le(sinkA._nSamplesProduced, maxDatasets));
+
+        for (std::size_t iC = 0; iC < sinkA._samples.size(); iC++) {
+            expect(eq(sinkA._samples[iC].signal_values.size(), totalSamples));
+        }
     };
 };
 

--- a/blocklib/picoscope/test/qa_Picoscope.cc
+++ b/blocklib/picoscope/test/qa_Picoscope.cc
@@ -27,12 +27,13 @@ void testRapidBlockBasic(std::size_t nrCaptures) {
 
     fmt::println("testRapidBlockBasic - {}", gr::meta::type_name<T>());
 
+    constexpr float      sampleRate   = 1234567.f;
     constexpr gr::Size_t kPreSamples  = 33;
     constexpr gr::Size_t kPostSamples = 1000;
     const gr::Size_t     totalSamples = nrCaptures * (kPreSamples + kPostSamples);
 
     Graph flowGraph;
-    auto& ps = flowGraph.emplaceBlock<PicoscopeT<T, AcquisitionMode::RapidBlock>>({{{"sample_rate", 10000.f},                                      //
+    auto& ps = flowGraph.emplaceBlock<PicoscopeT<T, AcquisitionMode::RapidBlock>>({{{"sample_rate", sampleRate},                                   //
         {"pre_samples", kPreSamples}, {"post_samples", kPostSamples}, {"acquisition_mode", "RapidBlock"}, {"rapid_block_nr_captures", nrCaptures}, //
         {"auto_arm", true}, {"trigger_once", true}, {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}},   //
         {"channel_couplings", std::vector<std::string>{"AC_1M"}}}});
@@ -73,12 +74,12 @@ void testStreamingBasics() {
 
     fmt::println("testStreamingBasics - {}", gr::meta::type_name<T>());
 
-    constexpr float kSampleRate = 80000.f;
+    constexpr float kSampleRate = 83000.f;
     constexpr auto  kDuration   = 2s;
 
-    auto& ps = flowGraph.emplaceBlock<PicoscopeT<T, AcquisitionMode::Streaming>>({{{"sample_rate", kSampleRate},                                                           //
-        {"acquisition_mode", "Streaming"}, {"streaming_mode_poll_rate", 0.00001f}, {"auto_arm", true}, {"channel_ids", std::vector<std::string>{"A"}},                     //
-        {"channel_names", std::vector<std::string>{"Test signal"}}, {"channel_units", std::vector<std::string>{"Test unit"}}, {"channel_ranges", std::vector<float>{5.f}}, //
+    auto& ps = flowGraph.emplaceBlock<PicoscopeT<T, AcquisitionMode::Streaming>>({{{"sample_rate", kSampleRate},                                                         //
+        {"acquisition_mode", "Streaming"}, {"streaming_mode_poll_rate", 0.00001f}, {"auto_arm", true}, {"channel_ids", std::vector<std::string>{"A"}},                   //
+        {"signal_names", std::vector<std::string>{"Test signal"}}, {"signal_units", std::vector<std::string>{"Test unit"}}, {"channel_ranges", std::vector<float>{5.f}}, //
         {"channel_couplings", std::vector<std::string>{"AC_1M"}}}});
 
     auto& tagMonitor = flowGraph.emplaceBlock<testing::TagMonitor<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", true}}});

--- a/blocklib/picoscope/test/qa_Picoscope.cc
+++ b/blocklib/picoscope/test/qa_Picoscope.cc
@@ -1,9 +1,9 @@
 #include <boost/ut.hpp>
 
 #include <gnuradio-4.0/Scheduler.hpp>
+#include <gnuradio-4.0/basic/clock_source.hpp>
 #include <gnuradio-4.0/testing/TagMonitors.hpp>
 
-#include <HelperBlocks.hpp>
 #include <Picoscope4000a.hpp>
 #include <Picoscope5000a.hpp>
 
@@ -22,7 +22,6 @@ template<gr::DataSetLike T>
 void testRapidBlockBasic(std::size_t nCaptures) {
     using namespace boost::ut;
     using namespace gr;
-    using namespace fair::helpers;
     using namespace fair::picoscope;
 
     fmt::println("testRapidBlockBasic({}) - {}", nCaptures, gr::meta::type_name<T>());
@@ -34,14 +33,14 @@ void testRapidBlockBasic(std::size_t nCaptures) {
     const gr::Size_t     totalSamples     = preSamples + postSamples;
 
     Graph flowGraph;
-    auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{{"disconnect_on_done", true}, {"sample_rate", sampleRate}, {"pre_samples", preSamples}, {"post_samples", postSamples}, {"n_captures", nCaptures}, //
-        {"auto_arm", true}, {"trigger_once", true}, {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}},                                                         //
-        {"channel_couplings", std::vector<std::string>{"AC_1M"}}}});
+    auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{"disconnect_on_done", true}, {"sample_rate", sampleRate}, {"pre_samples", preSamples}, {"post_samples", postSamples}, {"n_captures", nCaptures}, //
+        {"auto_arm", true}, {"trigger_once", true}, {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}},                                                        //
+        {"channel_couplings", std::vector<std::string>{"AC_1M"}}});
 
-    auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", false}}});
-    auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", false}}});
-    auto& sinkC = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-    auto& sinkD = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", false}});
+    auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", false}});
+    auto& sinkC = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+    auto& sinkD = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
 
     expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 0>(ps).template to<"in">(sinkA)));
     expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 1>(ps).template to<"in">(sinkB)));
@@ -49,10 +48,10 @@ void testRapidBlockBasic(std::size_t nCaptures) {
     expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 3>(ps).template to<"in">(sinkD)));
 
     if constexpr (std::is_same_v<Picoscope4000a<T>, PicoscopeT<T>>) {
-        auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+        auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+        auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+        auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
 
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
@@ -90,7 +89,6 @@ void testStreamingBasics() {
     using namespace std::chrono_literals;
     using namespace boost::ut;
     using namespace gr;
-    using namespace fair::helpers;
     using namespace fair::picoscope;
     Graph flowGraph;
 
@@ -99,16 +97,16 @@ void testStreamingBasics() {
     constexpr float sampleRate   = 83000.f;
     constexpr auto  testDuration = 2s;
 
-    auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{{"sample_rate", sampleRate},                                                                                      //
+    auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{"sample_rate", sampleRate},                                                                                       //
         {"streaming_mode_poll_rate", 0.00001f}, {"auto_arm", true}, {"channel_ids", std::vector<std::string>{"A"}},                                                      //
         {"signal_names", std::vector<std::string>{"Test signal"}}, {"signal_units", std::vector<std::string>{"Test unit"}}, {"channel_ranges", std::vector<float>{5.f}}, //
-        {"channel_couplings", std::vector<std::string>{"AC_1M"}}}});
+        {"channel_couplings", std::vector<std::string>{"AC_1M"}}});
 
-    auto& tagMonitor = flowGraph.emplaceBlock<testing::TagMonitor<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", true}}});
-    auto& sinkA      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-    auto& sinkB      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-    auto& sinkC      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-    auto& sinkD      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+    auto& tagMonitor = flowGraph.emplaceBlock<testing::TagMonitor<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", true}});
+    auto& sinkA      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+    auto& sinkB      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+    auto& sinkC      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+    auto& sinkD      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
 
     expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 0>(ps).template to<"in">(tagMonitor)));
     expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out">(tagMonitor).template to<"in">(sinkA)));
@@ -117,10 +115,10 @@ void testStreamingBasics() {
     expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 3>(ps).template to<"in">(sinkD)));
 
     if constexpr (std::is_same_v<Picoscope4000a<T>, PicoscopeT<T>>) {
-        auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+        auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+        auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+        auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
 
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
@@ -160,7 +158,6 @@ void testStreamingBasics() {
 const boost::ut::suite PicoscopeTests = [] {
     using namespace boost::ut;
     using namespace gr;
-    using namespace fair::helpers;
     using namespace fair::picoscope;
 
     "open and close"_test = [] {
@@ -169,6 +166,7 @@ const boost::ut::suite PicoscopeTests = [] {
 
         // this takes time, so we do it a few times only
         for (auto i = 0; i < 3; i++) {
+            expect(nothrow([&ps] { ps.open(); }));
             expect(nothrow([&ps] { ps.initialize(); }));
             expect(neq(ps.driverVersion(), std::string()));
             expect(neq(ps.hardwareVersion(), std::string()));
@@ -198,15 +196,15 @@ const boost::ut::suite PicoscopeTests = [] {
         using T                           = DataSet<float>;
 
         Graph flowGraph;
-        auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{{"sample_rate", 10000.f},                              //
+        auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{"sample_rate", 10000.f},                               //
             {"pre_samples", preSamples}, {"post_samples", postSamples}, {"n_captures", nCaptures},                //
             {"auto_arm", true}, {"trigger_once", true}, {"channel_ids", std::vector<std::string>{"A", "B", "C"}}, //
-            {"channel_ranges", std::vector<float>{{5.f, 5.f, 5.f}}}, {"channel_couplings", std::vector<std::string>{"AC_1M", "AC_1M", "AC_1M"}}}});
+            {"channel_ranges", std::vector<float>{{5.f, 5.f, 5.f}}}, {"channel_couplings", std::vector<std::string>{"AC_1M", "AC_1M", "AC_1M"}}});
 
-        auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", false}}});
-        auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", false}}});
-        auto& sinkC = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", false}}});
-        auto& sinkD = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", false}}});
+        auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", false}});
+        auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", false}});
+        auto& sinkC = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", false}});
+        auto& sinkD = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", false}});
 
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 0>(ps).template to<"in">(sinkA)));
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 1>(ps).template to<"in">(sinkB)));
@@ -214,10 +212,10 @@ const boost::ut::suite PicoscopeTests = [] {
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 3>(ps).template to<"in">(sinkD)));
 
         if constexpr (std::is_same_v<Picoscope4000a<T>, PicoscopeT<T>>) {
-            auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-            auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-            auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-            auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+            auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+            auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+            auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+            auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
 
             expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
             expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
@@ -247,6 +245,7 @@ const boost::ut::suite PicoscopeTests = [] {
     };
 
     "rapid block continuous"_test = [] {
+        fmt::println("rapid block continuous");
         using namespace std::chrono_literals;
 
         using T = DataSet<float>;
@@ -257,19 +256,19 @@ const boost::ut::suite PicoscopeTests = [] {
         constexpr gr::Size_t totalSamples = postSamples + preSamples;
         constexpr auto       testDuration = 3s;
 
-        const double      timePerDataset   = static_cast<double>(totalSamples) / sampleRate;
-        const double      testDurationSecs = std::chrono::duration<double>(testDuration).count();
+        const float       timePerDataset   = static_cast<float>(totalSamples) / sampleRate;
+        const float       testDurationSecs = std::chrono::duration<float>(testDuration).count();
         const std::size_t maxDatasets      = static_cast<size_t>(std::floor(testDurationSecs / timePerDataset));
         const std::size_t minDatasets      = 2UZ;
 
         Graph flowGraph;
-        auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{{"sample_rate", sampleRate}, {"pre_samples", preSamples}, {"post_samples", postSamples}, {"n_captures", gr::Size_t{1}}, {"auto_arm", true}, //
-            {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}}, {"channel_couplings", std::vector<std::string>{"AC_1M"}}}});
+        auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{"sample_rate", sampleRate}, {"pre_samples", preSamples}, {"post_samples", postSamples}, {"n_captures", gr::Size_t{1}}, {"auto_arm", true}, //
+            {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}}, {"channel_couplings", std::vector<std::string>{"AC_1M"}}});
 
-        auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", false}}});
-        auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkC = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-        auto& sinkD = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+        auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", false}});
+        auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+        auto& sinkC = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+        auto& sinkD = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
 
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 0>(ps).to<"in">(sinkA)));
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 1>(ps).template to<"in">(sinkB)));
@@ -277,10 +276,10 @@ const boost::ut::suite PicoscopeTests = [] {
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 3>(ps).template to<"in">(sinkD)));
 
         if constexpr (std::is_same_v<Picoscope4000a<T>, PicoscopeT<T>>) {
-            auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-            auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-            auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
-            auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", false}, {"log_tags", false}}});
+            auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+            auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+            auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+            auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
 
             expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
             expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
@@ -299,6 +298,82 @@ const boost::ut::suite PicoscopeTests = [] {
         fmt::println("rapid block continuous: producedDatasets:{}, valid range: [{}, {}]", sinkA._nSamplesProduced, minDatasets, maxDatasets);
         expect(ge(sinkA._nSamplesProduced, minDatasets));
         expect(le(sinkA._nSamplesProduced, maxDatasets));
+
+        for (std::size_t iC = 0; iC < sinkA._samples.size(); iC++) {
+            expect(eq(sinkA._samples[iC].signal_values.size(), totalSamples));
+        }
+    };
+
+    "rapid block arm/disarm trigger"_test = [] {
+        fmt::println("rapid block arm/disarm trigger");
+        using namespace std::chrono_literals;
+        using namespace gr::tag;
+
+        using T = DataSet<float>;
+
+        constexpr float      sampleRate   = 1000.f;
+        constexpr gr::Size_t postSamples  = 1000;
+        constexpr gr::Size_t preSamples   = 5;
+        constexpr gr::Size_t totalSamples = postSamples + preSamples;
+        constexpr auto       testDuration = 12s;
+
+        const auto createTriggerPropertyMap = [](const std::string& triggerName, const std::string& context, std::uint64_t time, float offset = 0.f) { //
+            return property_map{{TRIGGER_NAME.shortKey(), triggerName}, {TRIGGER_TIME.shortKey(), std::uint64_t{time}}, {TRIGGER_OFFSET.shortKey(), offset}, {CONTEXT.shortKey(), context}};
+        };
+
+        Graph flowGraph;
+        auto& clockSrc = flowGraph.emplaceBlock<gr::basic::ClockSource<std::uint8_t>>({{"sample_rate", sampleRate}, {"chunk_size", gr::Size_t(1)}, {"n_samples_max", gr::Size_t(0)}, {"name", "ClockSource"}, {"verbose_console", true}});
+
+        clockSrc.tags = {
+            Tag(1000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(1000))), // OK
+            Tag(3000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(3000))), // OK
+            Tag(3500, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(3500))), // This trigger will be ignored
+            Tag(3700, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(3700))), // This trigger will be ignored
+            Tag(5000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(5000))), // This trigger will be disarmed
+            Tag(5500, createTriggerPropertyMap("CMD_BP_STOP", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(5500))),  // disarm trigger
+            Tag(6000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(6000))), // OK
+            Tag(8000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(8000))), // This trigger will be disarmed
+            Tag(8500, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(8500))), // This trigger will be ignored
+            Tag(8700, createTriggerPropertyMap("CMD_BP_STOP", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(8700))),  // disarm trigger
+            Tag(8800, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(8800)))  // OK
+        }; // disarm trigger
+
+        auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{"sample_rate", sampleRate}, {"pre_samples", preSamples}, {"post_samples", postSamples},                                      //
+            {"trigger_arm", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"}, {"trigger_disarm", "CMD_BP_STOP/FAIR.SELECTOR.C=1:S=1:P=1"}, {"n_captures", gr::Size_t{1}}, {"auto_arm", false}, //
+            {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}}, {"channel_couplings", std::vector<std::string>{"AC_1M"}}});
+
+        auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", false}});
+        auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+        auto& sinkC = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+        auto& sinkD = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out">(clockSrc).to<"timingIn">(ps)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 0>(ps).to<"in">(sinkA)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 1>(ps).template to<"in">(sinkB)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 2>(ps).template to<"in">(sinkC)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 3>(ps).template to<"in">(sinkD)));
+
+        if constexpr (std::is_same_v<Picoscope4000a<T>, PicoscopeT<T>>) {
+            auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+            auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+            auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+            auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+
+            expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
+            expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
+            expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 6>(ps).template to<"in">(sinkG)));
+            expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 7>(ps).template to<"in">(sinkH)));
+        }
+
+        // Explicitly start unit because it takes quite some time
+        expect(nothrow([&ps] { ps.start(); }));
+        scheduler::Simple<scheduler::ExecutionPolicy::multiThreaded> sched{std::move(flowGraph)};
+        expect(sched.changeStateTo(lifecycle::State::INITIALISED).has_value());
+        expect(sched.changeStateTo(lifecycle::State::RUNNING).has_value());
+        std::this_thread::sleep_for(testDuration);
+        expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value());
+
+        expect(eq(sinkA._nSamplesProduced, 4UZ));
 
         for (std::size_t iC = 0; iC < sinkA._samples.size(); iC++) {
             expect(eq(sinkA._samples[iC].signal_values.size(), totalSamples));

--- a/blocklib/picoscope/test/qa_Picoscope.cc
+++ b/blocklib/picoscope/test/qa_Picoscope.cc
@@ -35,7 +35,7 @@ void testRapidBlockBasic(std::size_t nCaptures) {
     Graph flowGraph;
     auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{"disconnect_on_done", true}, {"sample_rate", sampleRate}, {"pre_samples", preSamples}, {"post_samples", postSamples}, {"n_captures", nCaptures}, //
         {"auto_arm", true}, {"trigger_once", true}, {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}},                                                        //
-        {"channel_couplings", std::vector<std::string>{"AC_1M"}}});
+        {"channel_couplings", std::vector<std::string>{"AC"}}});
 
     auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", false}});
     auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", false}});
@@ -100,7 +100,7 @@ void testStreamingBasics() {
     auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{"sample_rate", sampleRate},                                                                                       //
         {"streaming_mode_poll_rate", 0.00001f}, {"auto_arm", true}, {"channel_ids", std::vector<std::string>{"A"}},                                                      //
         {"signal_names", std::vector<std::string>{"Test signal"}}, {"signal_units", std::vector<std::string>{"Test unit"}}, {"channel_ranges", std::vector<float>{5.f}}, //
-        {"channel_couplings", std::vector<std::string>{"AC_1M"}}});
+        {"channel_couplings", std::vector<std::string>{"AC"}}});
 
     auto& tagMonitor = flowGraph.emplaceBlock<testing::TagMonitor<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", true}});
     auto& sinkA      = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
@@ -150,7 +150,7 @@ void testStreamingBasics() {
         expect(eq(std::get<float>(tag.at(std::string(tag::SAMPLE_RATE.shortKey()))), sampleRate));
         expect(eq(std::get<std::string>(tag.at(std::string(tag::SIGNAL_NAME.shortKey()))), "Test signal"s));
         expect(eq(std::get<std::string>(tag.at(std::string(tag::SIGNAL_UNIT.shortKey()))), "Test unit"s));
-        expect(eq(std::get<float>(tag.at(std::string(tag::SIGNAL_MIN.shortKey()))), 0.f));
+        expect(eq(std::get<float>(tag.at(std::string(tag::SIGNAL_MIN.shortKey()))), -5.f));
         expect(eq(std::get<float>(tag.at(std::string(tag::SIGNAL_MAX.shortKey()))), 5.f));
     }
 }
@@ -200,7 +200,7 @@ const boost::ut::suite PicoscopeTests = [] {
         auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{"sample_rate", 10000.f},                               //
             {"pre_samples", preSamples}, {"post_samples", postSamples}, {"n_captures", nCaptures},                //
             {"auto_arm", true}, {"trigger_once", true}, {"channel_ids", std::vector<std::string>{"A", "B", "C"}}, //
-            {"channel_ranges", std::vector<float>{{5.f, 5.f, 5.f}}}, {"channel_couplings", std::vector<std::string>{"AC_1M", "AC_1M", "AC_1M"}}});
+            {"channel_ranges", std::vector<float>{{5.f, 5.f, 5.f}}}, {"channel_couplings", std::vector<std::string>{"AC", "AC", "AC"}}});
 
         auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", false}});
         auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", false}});
@@ -264,7 +264,7 @@ const boost::ut::suite PicoscopeTests = [] {
 
         Graph flowGraph;
         auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{"sample_rate", sampleRate}, {"pre_samples", preSamples}, {"post_samples", postSamples}, {"n_captures", gr::Size_t{1}}, {"auto_arm", true}, //
-            {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}}, {"channel_couplings", std::vector<std::string>{"AC_1M"}}});
+            {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}}, {"channel_couplings", std::vector<std::string>{"AC"}}});
 
         auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", false}});
         auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
@@ -341,7 +341,7 @@ const boost::ut::suite PicoscopeTests = [] {
 
         auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{"sample_rate", sampleRate}, {"pre_samples", preSamples}, {"post_samples", postSamples},                                      //
             {"trigger_arm", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"}, {"trigger_disarm", "CMD_BP_STOP/FAIR.SELECTOR.C=1:S=1:P=1"}, {"n_captures", gr::Size_t{1}}, {"auto_arm", false}, //
-            {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}}, {"channel_couplings", std::vector<std::string>{"AC_1M"}}});
+            {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}}, {"channel_couplings", std::vector<std::string>{"AC"}}});
 
         auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", false}});
         auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
@@ -407,7 +407,7 @@ const boost::ut::suite PicoscopeTests = [] {
 
         auto& ps = flowGraph.emplaceBlock<PicoscopeT<T>>({{"sample_rate", sampleRate}, {"pre_samples", preSamples}, {"post_samples", postSamples},                                  //
             {"trigger_arm", "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"}, {"trigger_disarm", "CMD_BP_STOP/FAIR.SELECTOR.C=1:S=1:P=1"}, {"n_captures", nCaptures}, {"auto_arm", false}, //
-            {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}}, {"channel_couplings", std::vector<std::string>{"AC_1M"}}});
+            {"channel_ids", std::vector<std::string>{"A"}}, {"channel_ranges", std::vector<float>{5.f}}, {"channel_couplings", std::vector<std::string>{"AC"}}});
 
         auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", false}});
         auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<T, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});

--- a/blocklib/picoscope/test/qa_Picoscope.cc
+++ b/blocklib/picoscope/test/qa_Picoscope.cc
@@ -189,6 +189,7 @@ const boost::ut::suite PicoscopeTests = [] {
     "rapid block multiple captures"_test = [] { testRapidBlockBasic<DataSet<float>>(3); };
 
     "rapid block 3 channels"_test = [] {
+        fmt::println("rapid block 3 channels");
         constexpr gr::Size_t preSamples   = 33;
         constexpr gr::Size_t postSamples  = 1000;
         constexpr gr::Size_t nCaptures    = 5;

--- a/blocklib/picoscope/test/qa_Picoscope.cc
+++ b/blocklib/picoscope/test/qa_Picoscope.cc
@@ -1,7 +1,7 @@
 #include <boost/ut.hpp>
 
 #include <gnuradio-4.0/Scheduler.hpp>
-#include <gnuradio-4.0/basic/clock_source.hpp>
+#include <gnuradio-4.0/basic/ClockSource.hpp>
 #include <gnuradio-4.0/testing/TagMonitors.hpp>
 
 #include <Picoscope4000a.hpp>

--- a/blocklib/picoscope/test/qa_PicoscopePerformanceMonitor.cc
+++ b/blocklib/picoscope/test/qa_PicoscopePerformanceMonitor.cc
@@ -51,7 +51,7 @@ int main(int argc, char* argv[]) {
     // Replace with your connected Picoscope device
     using PicoscopeT = Picoscope4000a<SampleType, AcquisitionMode::Streaming>;
 
-    constexpr float kSampleRate = 20'000'000.f;
+    constexpr float kSampleRate = 16'500'000.f;
 
     auto threadPool = std::make_shared<gr::thread_pool::BasicThreadPool>("custom pool", gr::thread_pool::CPU_BOUND, 2, 2);
 

--- a/blocklib/picoscope/test/qa_PicoscopeTiming.cc
+++ b/blocklib/picoscope/test/qa_PicoscopeTiming.cc
@@ -41,13 +41,12 @@ const boost::ut::suite PicoscopeTests = [] {
 
         auto& ps = flowGraph.emplaceBlock<Picoscope4000a<float, AcquisitionMode::Streaming>>({{
             {"sample_rate", kSampleRate},                                               //
-            {"acquisition_mode", "Streaming"},                                          //
             {"auto_arm", true},                                                         //
             {"channel_ids", std::vector<std::string>{"A", "B", "C"}},                   //
-            {"channel_names", std::vector<std::string>{"Trigger", "IO2", "IO3"}},       //
-            {"channel_units", std::vector<std::string>{"V", "V", "V"}},                 //
+            {"signal_names", std::vector<std::string>{"Trigger", "IO2", "IO3"}},        //
+            {"signal_units", std::vector<std::string>{"V", "V", "V"}},                  //
             {"channel_ranges", std::vector<float>{5.f, 5.f, 5.f}},                      //
-            {"channel_offsets", std::vector<float>{0.f, 0.f, 0.f}},                     //
+            {"signal_offsets", std::vector<float>{0.f, 0.f, 0.f}},                      //
             {"channel_couplings", std::vector<std::string>{"DC_1M", "DC_1M", "DC_1M"}}, //
             {"trigger_source", "A"},                                                    //
             {"trigger_threshold", 1.7f},                                                //

--- a/blocklib/picoscope/test/qa_PicoscopeTiming.cc
+++ b/blocklib/picoscope/test/qa_PicoscopeTiming.cc
@@ -53,14 +53,27 @@ const boost::ut::suite PicoscopeTests = [] {
             {"trigger_direction", "Rising"}                                      //
         }});
 
-        auto& sinkA = flowGraph.emplaceBlock<gr::testing::TagSink<float, gr::testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", true}}});
-        auto& sinkB = flowGraph.emplaceBlock<gr::testing::TagSink<float, gr::testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", true}}});
-        auto& sinkC = flowGraph.emplaceBlock<gr::testing::TagSink<float, gr::testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", true}}});
+        auto& sinkA = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", true}});
+        auto& sinkB = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", true}});
+        auto& sinkC = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", true}, {"log_tags", true}});
+        auto& sinkD = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+        auto& sinkE = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+        auto& sinkF = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+        auto& sinkG = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+        auto& sinkH = flowGraph.emplaceBlock<testing::TagSink<float, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
 
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out">(timingSrc).template to<"timingIn">(ps)));
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 0>(ps).template to<"in">(sinkA)));
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 1>(ps).template to<"in">(sinkB)));
         expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 2>(ps).template to<"in">(sinkC)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 3>(ps).template to<"in">(sinkD)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 4>(ps).template to<"in">(sinkE)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 5>(ps).template to<"in">(sinkF)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 6>(ps).template to<"in">(sinkG)));
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"out", 7>(ps).template to<"in">(sinkH)));
+
+        auto& sinkDigital = flowGraph.emplaceBlock<testing::TagSink<uint16_t, testing::ProcessFunction::USE_PROCESS_BULK>>({{"log_samples", false}, {"log_tags", false}});
+        expect(eq(ConnectionResult::SUCCESS, flowGraph.connect<"digitalOut">(ps).template to<"in">(sinkDigital)));
 
         // Explicitly start unit because it takes quite some time
         expect(nothrow([&ps] { ps.start(); }));

--- a/blocklib/picoscope/test/qa_PicoscopeTiming.cc
+++ b/blocklib/picoscope/test/qa_PicoscopeTiming.cc
@@ -40,17 +40,17 @@ const boost::ut::suite PicoscopeTests = [] {
         });
 
         auto& ps = flowGraph.emplaceBlock<Picoscope4000a<float>>({{
-            {"sample_rate", kSampleRate},                                               //
-            {"auto_arm", true},                                                         //
-            {"channel_ids", std::vector<std::string>{"A", "B", "C"}},                   //
-            {"signal_names", std::vector<std::string>{"Trigger", "IO2", "IO3"}},        //
-            {"signal_units", std::vector<std::string>{"V", "V", "V"}},                  //
-            {"channel_ranges", std::vector<float>{5.f, 5.f, 5.f}},                      //
-            {"signal_offsets", std::vector<float>{0.f, 0.f, 0.f}},                      //
-            {"channel_couplings", std::vector<std::string>{"DC_1M", "DC_1M", "DC_1M"}}, //
-            {"trigger_source", "A"},                                                    //
-            {"trigger_threshold", 1.7f},                                                //
-            {"trigger_direction", "Rising"}                                             //
+            {"sample_rate", kSampleRate},                                        //
+            {"auto_arm", true},                                                  //
+            {"channel_ids", std::vector<std::string>{"A", "B", "C"}},            //
+            {"signal_names", std::vector<std::string>{"Trigger", "IO2", "IO3"}}, //
+            {"signal_units", std::vector<std::string>{"V", "V", "V"}},           //
+            {"channel_ranges", std::vector<float>{5.f, 5.f, 5.f}},               //
+            {"signal_offsets", std::vector<float>{0.f, 0.f, 0.f}},               //
+            {"channel_couplings", std::vector<std::string>{"DC", "DC", "DC"}},   //
+            {"trigger_source", "A"},                                             //
+            {"trigger_threshold", 1.7f},                                         //
+            {"trigger_direction", "Rising"}                                      //
         }});
 
         auto& sinkA = flowGraph.emplaceBlock<gr::testing::TagSink<float, gr::testing::ProcessFunction::USE_PROCESS_BULK>>({{{"log_samples", true}, {"log_tags", true}}});

--- a/blocklib/picoscope/test/qa_PicoscopeTiming.cc
+++ b/blocklib/picoscope/test/qa_PicoscopeTiming.cc
@@ -39,7 +39,7 @@ const boost::ut::suite PicoscopeTests = [] {
             {"verbose_console", false}                                                                                     //
         });
 
-        auto& ps = flowGraph.emplaceBlock<Picoscope4000a<float, AcquisitionMode::Streaming>>({{
+        auto& ps = flowGraph.emplaceBlock<Picoscope4000a<float>>({{
             {"sample_rate", kSampleRate},                                               //
             {"auto_arm", true},                                                         //
             {"channel_ids", std::vector<std::string>{"A", "B", "C"}},                   //
@@ -125,7 +125,7 @@ const boost::ut::suite PicoscopeTests = [] {
         expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value());
 
         const auto measuredRate = static_cast<double>(sinkA._nSamplesProduced) / duration<double>(kDuration).count();
-        fmt::println("Produced in worker: {}", ps.producedWorker());
+        fmt::println("Produced in worker: {}", ps._nSamplesPublished);
         fmt::println("Configured rate: {}, Measured rate: {} ({:.2f}%), Duration: {} ms", kSampleRate, static_cast<std::size_t>(measuredRate), measuredRate / static_cast<double>(kSampleRate) * 100., duration_cast<milliseconds>(kDuration).count());
         fmt::println("Total: {}", sinkA._nSamplesProduced);
 


### PR DESCRIPTION
This PR introduces updates to the `Picoscope` block, with the main changes including:  

- Reimplementation of `RapidBlock` mode with `DataSet` support, where the output type determines the acquisition mode.  
- Option to process only completed captures in `RapidBlock` mode.  
- Support for arming/disarming input triggers.  
- Proper conversions to timebase and time interval.  
- Add support for picoscope 3000 series.
- Implement digital input and `digitalOut` port

Additional changes:  

- Removal of validation between desired and actual sample rate.  
- Refactoring: Eliminated `Settings`, `TriggerSettings`, etc., establishing a single source of truth.  
- Introduction of an internal `TagReader` for the `work()` function.  
- Fix Picoscope performance monitor.  
- General refactoring and code clean-up.  
- Correction of actual sample rate calculation.  
- Renaming of certain settings from `channel_` to `signal_` prefix.  
- device resolution