### PR TITLE
Docker: update timing dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN sudo apt-get update && sudo apt-get -y install build-essential pkg-config &&
 RUN sudo apt-get update \
     && sudo apt-get -y install build-essential autoconf automake libtool \
     && cd $(mktmp -d) \
-    && git clone --branch v2.1.3 --depth=1 https://ohwr.org/project/etherbone-core.git \
+    && git clone --branch v2.1.4 --depth=1 https://gitlab.com/ohwr/project/etherbone-core.git \
     && cd etherbone-core/api \
     && touch ChangeLog \
     && sed -e "s%AC_MSG_ERROR%AC_MSG_NOTICE%g" -i configure.ac \
@@ -24,7 +24,7 @@ RUN sudo apt-get update \
 RUN sudo apt-get update \
     && sudo apt-get -y install libsigc++-2.0-dev libxslt1-dev libboost-all-dev \
     && cd $(mktmp -d) \
-    && git clone --branch v3.0.3 --depth=1 https://github.com/GSI-CS-CO/saftlib.git \
+    && git clone --branch v3.1.4 --depth=1 https://github.com/GSI-CS-CO/saftlib.git \
     && cd saftlib \
     && ./autogen.sh \
     && ./configure \
@@ -36,8 +36,8 @@ RUN sudo apt-get update \
 
 # Install picoscope libraries https://www.picotech.com/downloads/linux
 RUN sudo apt-get update \
-    && ( wget -O - https://labs.picotech.com/Release.gpg.key|sudo apt-key add - ) \
-    && sudo add-apt-repository 'deb https://labs.picotech.com/rc/picoscope7/debian/ picoscope main' \
+    && ( wget -O - https://labs.picotech.com/Release.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/picotech.gpg ) \
+    && (echo 'deb [signed-by=/usr/share/keyrings/picotech.gpg] https://labs.picotech.com/rc/picoscope7/debian/ picoscope main' | sudo tee /etc/apt/sources.list.d/picoscope.list )  \
     && sudo apt update \
     && ( sudo apt install -y udev libusb-1.0-0-dev libps3000a libps4000a libps5000a libps6000 libps6000a libx11-dev libgl1-mesa-dev libsdl2-dev || true ) \
     && sudo apt-get clean \


### PR DESCRIPTION
updates etherbone and saftlib to the latest releases. This will also rebuild the Docker container to be based on the latest gr4-build container, so gr-digitizers and opendigitizer will get built with emscripten 4.