### PR TITLE
Add matcher diagnistics and bug fixing

### DIFF
--- a/blocklib/picoscope/Picoscope.hpp
+++ b/blocklib/picoscope/Picoscope.hpp
@@ -791,12 +791,12 @@ public:
         // save the unpublished part of the chunk to be reprocessed in the next iteration
         for (std::size_t channelIdx = 0; channelIdx < _channels.size(); channelIdx++) {
             // todo: this drops some samples if less than the new samples is processed
-            auto processedEnd = offset + ((triggerTags.processedSamples > _channels[channelIdx].unpublishedSamples.size()) ? ( triggerTags.processedSamples - _channels[channelIdx].unpublishedSamples.size()) : 0);
+            auto processedEnd = offset + ((triggerTags.processedSamples > _channels[channelIdx].unpublishedSamples.size()) ? (triggerTags.processedSamples - _channels[channelIdx].unpublishedSamples.size()) : 0);
             if ((processedEnd >= _channels[channelIdx].driverBuffer.size()) || (processedEnd + availableSamples - triggerTags.processedSamples > _channels[channelIdx].driverBuffer.size())) {
                 std::println("Error: prevented out of bounds read of driver data[{}, {}], offset={}, triggerTags.processedSamples={}, _chan.unpublishedSamples.size()={}, availableSamples={}", //
-                           processedEnd, processedEnd + availableSamples - triggerTags.processedSamples, offset, triggerTags.processedSamples, _channels[channelIdx].unpublishedSamples.size(), availableSamples);
+                    processedEnd, processedEnd + availableSamples - triggerTags.processedSamples, offset, triggerTags.processedSamples, _channels[channelIdx].unpublishedSamples.size(), availableSamples);
             } else {
-                const auto driverData   = std::span(_channels[channelIdx].driverBuffer).subspan(processedEnd, availableSamples - triggerTags.processedSamples);
+                const auto driverData = std::span(_channels[channelIdx].driverBuffer).subspan(processedEnd, availableSamples - triggerTags.processedSamples);
                 _channels[channelIdx].unpublishedSamples.clear();
                 std::ranges::copy(driverData, std::back_inserter(_channels[channelIdx].unpublishedSamples));
             }

--- a/blocklib/picoscope/Picoscope.hpp
+++ b/blocklib/picoscope/Picoscope.hpp
@@ -269,8 +269,6 @@ struct Picoscope : public PicoscopeBlockingHelper<TPSImpl, gr::DataSetLike<T>>::
 
     int _digitalChannelNumber = -1; // used only if digital trigger is set
 
-    std::vector<gr::Tag> _unpublishedDroppedSamplesTags;
-
     GR_MAKE_REFLECTABLE(Picoscope, timingIn, digitalOut, serial_number, sample_rate, pre_samples, post_samples, n_captures, streaming_mode_poll_rate,                                 //
         auto_arm, trigger_once, channel_ids, signal_names, signal_units, signal_quantities, channel_ranges, channel_analog_offsets, signal_scales, signal_offsets, channel_couplings, //
         trigger_source, trigger_threshold, trigger_direction, digital_port_threshold, digital_port_invert_output, trigger_arm, trigger_disarm, systemtime_interval, matcher_timeout);
@@ -738,8 +736,7 @@ public:
     void processDriverDataStreaming(std::size_t nSamples, std::size_t offset, gr::InputSpanLike auto& timingInSpan, gr::OutputSpanLike auto& digitalOutSpan, std::span<TOutSpan>& outputs, std::chrono::nanoseconds acquisitionTime)
     requires(acquisitionMode == AcquisitionMode::Streaming)
     {
-        std::size_t       availableSamples = calculateAvailableOutputs(nSamples, digitalOutSpan, outputs);
-        const std::size_t nDroppedSamples  = nSamples - availableSamples;
+        std::size_t availableSamples = calculateAvailableOutputs(nSamples, digitalOutSpan, outputs);
 
         for (std::size_t channelIdx = 0; channelIdx < _channels.size(); channelIdx++) {
             processSamplesOneChannel<T>(availableSamples, offset, _channels[channelIdx], outputs[channelIdx]);
@@ -754,52 +751,22 @@ public:
         auto                     triggerOffsets = findAnalogTriggers(_channels[triggerSourceIndex.value()], samples);
         std::span<const gr::Tag> tagspan        = std::span(timingInSpan.rawTags);
         auto                     tags           = tagspan | std::views::transform([](const auto& t) { return t.map; }) | std::ranges::to<std::vector<gr::property_map>>();
-        // Always provide nSamples to match() so dropped samples are considered
-        auto triggerTags = tagMatcher.match(tags, triggerOffsets, nSamples, acquisitionTime - acquisitionTimeOffset);
+        auto                     triggerTags    = tagMatcher.match(tags, triggerOffsets, availableSamples, acquisitionTime - acquisitionTimeOffset);
 
-        if (nDroppedSamples > 0) {
-            _unpublishedDroppedSamplesTags.emplace_back(availableSamples, gr::property_map{{gr::tag::N_DROPPED_SAMPLES.shortKey(), static_cast<gr::Size_t>(nDroppedSamples)}});
-        }
-        const std::size_t nDroppedSamplesLimit              = triggerTags.processedSamples;
-        auto              firstUnpublishedDroppedSamplesTag = std::ranges::find_if(_unpublishedDroppedSamplesTags, [nDroppedSamplesLimit](const gr::Tag& t) { return t.index < nDroppedSamplesLimit; });
-        const bool        haveUnpublishedDroppedSamples     = firstUnpublishedDroppedSamplesTag != _unpublishedDroppedSamplesTags.end();
-
-        // Tags must be published in order of their index, so the merged vector must be sorted.
-        // mergedTags vector stores only pointers to Tag to avoid Tag copying.
-        // But do it only if _unpublishedDroppedSamplesTags not empty
-        std::vector<const gr::Tag*> mergedTags;
-
-        if (haveUnpublishedDroppedSamples) {
-            mergedTags.reserve(_unpublishedDroppedSamplesTags.size() + triggerTags.tags.size());
-            for (auto it = firstUnpublishedDroppedSamplesTag; it != _unpublishedDroppedSamplesTags.end(); ++it) {
-                if (it->index < nDroppedSamplesLimit) {
-                    mergedTags.push_back(&*it);
-                }
+        // publish tags
+        for (std::size_t channelIdx = 0; channelIdx < _channels.size(); ++channelIdx) {
+            auto& channel = _channels[channelIdx];
+            auto& output  = outputs[channelIdx];
+            if (!channel.signalInfoTagPublished) {
+                output.publishTag(channel.toTagMap(), 0);
+                channel.signalInfoTagPublished = true;
             }
-            for (auto& t : triggerTags.tags) {
-                mergedTags.push_back(&t);
+            if (triggerTags.tags.empty()) {
+                continue;
             }
-            std::ranges::sort(mergedTags, std::less{}, [](const gr::Tag* p) { return p->index; });
-        }
-
-        auto publishTagsForAllChannels = [&](const auto& tags) {
-            for (std::size_t channelIdx = 0; channelIdx < _channels.size(); ++channelIdx) {
-                auto& channel = _channels[channelIdx];
-                auto& output  = outputs[channelIdx];
-                if (!channel.signalInfoTagPublished) {
-                    output.publishTag(channel.toTagMap(), 0);
-                    channel.signalInfoTagPublished = true;
-                }
-                for (const gr::Tag* tag : tags) {
-                    output.publishTag(tag->map, tag->index);
-                }
+            for (auto& [index, map] : triggerTags.tags) {
+                output.publishTag(map, index);
             }
-        };
-
-        if (mergedTags.empty()) {
-            publishTagsForAllChannels(triggerTags.tags | std::views::transform([](auto& t) { return &t; }));
-        } else {
-            publishTagsForAllChannels(mergedTags);
         }
 
         self().copyDigitalBuffersToOutput(digitalOutSpan, triggerTags.processedSamples);
@@ -819,13 +786,6 @@ public:
             // Otherwise, tags will not be propagated correctly.
             // const std::size_t nSamplesToPublish = i < _state.channels.size() ? availableSamples : 0UZ;
             outputs[i].publish(triggerTags.processedSamples);
-        }
-
-        if (!_unpublishedDroppedSamplesTags.empty()) {
-            _unpublishedDroppedSamplesTags.erase(std::remove_if(_unpublishedDroppedSamplesTags.begin(), _unpublishedDroppedSamplesTags.end(), [nDroppedSamplesLimit](const gr::Tag& t) { return t.index < nDroppedSamplesLimit; }), _unpublishedDroppedSamplesTags.end());
-            for (auto& tag : _unpublishedDroppedSamplesTags) {
-                tag.index = tag.index >= triggerTags.processedSamples ? tag.index - triggerTags.processedSamples : 0;
-            }
         }
 
         // save the unpublished part of the chunk to be reprocessed in the next iteration

--- a/blocklib/picoscope/Picoscope.hpp
+++ b/blocklib/picoscope/Picoscope.hpp
@@ -831,10 +831,15 @@ public:
         // save the unpublished part of the chunk to be reprocessed in the next iteration
         for (std::size_t channelIdx = 0; channelIdx < _channels.size(); channelIdx++) {
             // todo: this drops some samples if less than the new samples is processed
-            auto       processedEnd = offset + ((triggerTags.processedSamples > _channels[channelIdx].unpublishedSamples.size()) ? (triggerTags.processedSamples - _channels[channelIdx].unpublishedSamples.size()) : 0);
-            const auto driverData   = std::span(_channels[channelIdx].driverBuffer).subspan(processedEnd, availableSamples - triggerTags.processedSamples);
-            _channels[channelIdx].unpublishedSamples.clear();
-            std::ranges::copy(driverData, std::back_inserter(_channels[channelIdx].unpublishedSamples));
+            auto processedEnd = offset + ((triggerTags.processedSamples > _channels[channelIdx].unpublishedSamples.size()) ? ( triggerTags.processedSamples - _channels[channelIdx].unpublishedSamples.size()) : 0);
+            if ((processedEnd >= _channels[channelIdx].driverBuffer.size()) || (processedEnd + availableSamples - triggerTags.processedSamples > _channels[channelIdx].driverBuffer.size())) {
+                std::println("Error: prevented out of bounds read of driver data[{}, {}], offset={}, triggerTags.processedSamples={}, _chan.unpublishedSamples.size()={}, availableSamples={}", //
+                           processedEnd, processedEnd + availableSamples - triggerTags.processedSamples, offset, triggerTags.processedSamples, _channels[channelIdx].unpublishedSamples.size(), availableSamples);
+            } else {
+                const auto driverData   = std::span(_channels[channelIdx].driverBuffer).subspan(processedEnd, availableSamples - triggerTags.processedSamples);
+                _channels[channelIdx].unpublishedSamples.clear();
+                std::ranges::copy(driverData, std::back_inserter(_channels[channelIdx].unpublishedSamples));
+            }
         }
 
         _nSamplesPublished += triggerTags.processedSamples;

--- a/blocklib/picoscope/TimingMatcher.hpp
+++ b/blocklib/picoscope/TimingMatcher.hpp
@@ -75,6 +75,9 @@ struct TimingMatcher {
     }
 
     std::optional<gr::Tag> alignTagRelativeToLastMatched(const gr::property_map& currentTag) {
+        if (!_lastMatchedTag.has_value()) {
+            return std::nullopt;
+        }
         float      Ts               = 1e9f / sampleRate;
         const auto currentTagWRTime = std::chrono::nanoseconds(std::get<unsigned long>(currentTag.at(gr::tag::TRIGGER_TIME.shortKey())));
         const auto currentTagOffset = std::chrono::nanoseconds(static_cast<unsigned long>(std::get<float>(currentTag.at(gr::tag::TRIGGER_OFFSET.shortKey()))));

--- a/blocklib/picoscope/TimingMatcher.hpp
+++ b/blocklib/picoscope/TimingMatcher.hpp
@@ -184,6 +184,15 @@ struct TimingMatcher {
                 continue;
             }
 
+            std::optional<gr::Tag> realignedDiagTag = alignTagRelativeToLastMatched(currentTag);
+            if (realignedDiagTag) {
+                const std::size_t indexTolerance = 3;
+                if (std::max(realignedDiagTag->index, currentFlankIndex) - std::min(realignedDiagTag->index, currentFlankIndex) > indexTolerance) {
+                    std::println("TimingMatcher. Possible wrong matching, lastMatchedTag can be wrongly assigned. Difference between currentTagIndex:{} and currentFlankIndex:{} is more than tolerance ({})", //
+                        realignedDiagTag->index, currentFlankIndex, indexTolerance);
+                }
+            }
+
             // regular case, next hw edge belongs to the next tag
             _lastMatchedTag = {currentFlankIndex, std::chrono::nanoseconds(currentTagWRTime).count()};
             while (unmatchedEvents > 0) { // align all previously unaligned tags relative to this one

--- a/blocklib/picoscope/test/qa_TimingMatcher.cc
+++ b/blocklib/picoscope/test/qa_TimingMatcher.cc
@@ -60,8 +60,6 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
         expect(eq(triggerSampleIndices.size(), result.processedTags));
         expect(eq(240uz, result.processedSamples));
-        expect(eq(-40, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 200'000, matcher._lastMatchedTag.value().second));
         expectRangesEquals(
             std::vector<gr::Tag>{
                 {100, generateTimingTag("EVT_CMD1"s, acqTimestamp + 100'000, 0.0f, true)},
@@ -87,8 +85,6 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
         expect(eq(5, result.processedTags));
         expect(eq(240uz, result.processedSamples));
-        expect(eq(-40, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 200'000, matcher._lastMatchedTag.value().second));
         expectRangesEquals(
             std::vector<gr::Tag>{
                 {100, generateTimingTag("EVT_CMD1"s, acqTimestamp + 100'000, 0.0f, true)},
@@ -116,8 +112,6 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
         expect(eq(5, result.processedTags));
         expect(eq(240uz, result.processedSamples));
-        expect(eq(-40, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 200'000, matcher._lastMatchedTag.value().second));
         expectRangesEquals(
             std::vector<gr::Tag>{
                 {100, generateTimingTag("EVT_CMD1"s, acqTimestamp + 100'000, 0.0f, true)},
@@ -145,8 +139,6 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
         expect(eq(5uz, result.processedTags));
         expect(eq(240uz, result.processedSamples));
-        expect(eq(-40, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 200'000, matcher._lastMatchedTag.value().second));
         expectRangesEquals(
             std::vector<gr::Tag>{
                 {100, generateTimingTag("EVT_CMD1", acqTimestamp + 100'000, 0.0f, true)},
@@ -170,8 +162,6 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
         expect(eq(3uz, result.processedTags));
         expect(eq(1'240uz, result.processedSamples));
-        expect(eq(-40, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 1'200'000, matcher._lastMatchedTag.value().second));
         std::vector<gr::Tag> expected{
             {100, generateUnknownTag("UNKNOWN_EVENT", acqTimestamp + 100'000, 0.0f, false)},
             {150, generateUnknownTag("UNKNOWN_EVENT", acqTimestamp + 150'000, 0.0f, false)},
@@ -198,8 +188,6 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
         expect(eq(4uz, result.processedTags));
         expect(eq(240uz, result.processedSamples));
-        expect(eq(-40, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 200'000, matcher._lastMatchedTag.value().second));
         expect(approx(std::get<float>(result.tags[2].map.at(gr::tag::TRIGGER_OFFSET.shortKey())), 0.0f, 1e-10f));
         result.tags[2].map.at(gr::tag::TRIGGER_OFFSET.shortKey()) = 0.0f;
 
@@ -228,8 +216,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
         expect(eq(4uz, result.processedTags));
         expect(eq(240uz, result.processedSamples));
-        expect(eq(-40, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 200'000, matcher._lastMatchedTag.value().second));
+
         expectRangesEquals(
             std::vector<gr::Tag>{
                 {100, generateTimingTag("EVT_CMD1", acqTimestamp + 100'000, 0.0f, true)},
@@ -255,8 +242,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
         expect(eq(4uz, result.processedTags));
         expect(eq(240uz, result.processedSamples));
-        expect(eq(-40, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 200'000, matcher._lastMatchedTag.value().second));
+
         expectRangesEquals(
             std::vector<gr::Tag>{
                 {100, generateTimingTag("EVT_CMD1", acqTimestamp + 100'000, 0.0f, true)},
@@ -282,8 +268,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
         expect(eq(4uz, result.processedTags));
         expect(eq(240uz, result.processedSamples));
-        expect(eq(-40, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 200'000, matcher._lastMatchedTag.value().second));
+
         expectRangesEquals(
             std::vector<gr::Tag>{
                 {100, generateTimingTag("EVT_CMD1", acqTimestamp + 100'000, 0.0f, true)},
@@ -308,8 +293,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
         expect(eq(3uz, result.processedTags));
         expect(eq(1991uz, result.processedSamples));
-        expect(eq(-1791, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 200'000, matcher._lastMatchedTag.value().second));
+
         expectRangesEquals(
             std::vector<gr::Tag>{
                 {100, generateTimingTag("EVT_CMD1", acqTimestamp + 100'000, 0.0f, true)},
@@ -335,8 +319,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
         expect(eq(3uz, result.processedTags));
         expect(eq(240uz, result.processedSamples));
-        expect(eq(-40, matcher._lastMatchedTag.value().first));
-        expect(eq(wrTimestamp + 200'000, matcher._lastMatchedTag.value().second));
+
         expectRangesEquals(
             std::vector<gr::Tag>{
                 {100, generateTimingTag("EVT_CMD1", wrTimestamp + 100'000, 0.0f, true, acqTimestamp + 100'000)},
@@ -362,8 +345,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
         expect(eq(4uz, result.processedTags));
         expect(eq(240uz, result.processedSamples));
-        expect(eq(-40, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 200'000, matcher._lastMatchedTag.value().second));
+
         expectRangesEquals(
             std::vector<gr::Tag>{
                 {100, generateTimingTag("EVT_CMD1", acqTimestamp + 100'000, 0.0f, true)},
@@ -391,8 +373,6 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
         expect(eq(triggerSampleIndices.size(), result.processedTags));
         expect(eq(240uz, result.processedSamples));
-        expect(eq(-40, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 200'000, matcher._lastMatchedTag.value().second));
 
         // check and fix inexact offsets
         expect(approx(std::get<float>(result.tags[0].map.at(gr::tag::TRIGGER_OFFSET.shortKey())), 0.0f, 1e-10f));
@@ -425,8 +405,6 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
             auto          result = matcher.match(std::vector<gr::property_map>{}, triggerSampleIndices, 250uz, std::chrono::nanoseconds(acqTimestamp));
             expect(eq(result.processedTags, 0uz));
             expect(eq(result.processedSamples, 240uz));
-            expect(eq(false, matcher._lastMatchedTag.has_value()));
-
             expectRangesEquals(
                 std::vector<gr::Tag>{
                     {100, generateUnknownTag("UNKNOWN_EVENT", acqTimestamp + 100'000, 0.0f, false)},
@@ -440,8 +418,6 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
             auto          result = matcher.match(tags, std::vector<std::size_t>{}, 250uz, std::chrono::nanoseconds(acqTimestamp));
             expect(eq(result.processedTags, 3uz));
             expect(eq(result.processedSamples, 240uz));
-            expect(eq(false, matcher._lastMatchedTag.has_value()));
-
             expectRangesEquals(std::vector<gr::Tag>{}, result.tags);
         }
         { // empty hw edge list
@@ -449,8 +425,6 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
             auto          result = matcher.match(std::vector<gr::property_map>{}, std::vector<std::size_t>{}, 250uz, std::chrono::nanoseconds(acqTimestamp));
             expect(eq(result.processedTags, 0uz));
             expect(eq(result.processedSamples, 240uz));
-            expect(eq(false, matcher._lastMatchedTag.has_value()));
-
             expectRangesEquals(std::vector<gr::Tag>{}, result.tags);
         }
     };
@@ -469,9 +443,6 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
             expect(eq(2uz, result.processedTags));
             expect(eq(4uz, result.processedSamples)); // processed up to the last matching tag
-            expect(eq(0, matcher._lastMatchedTag.value().first));
-            expect(eq(acqTimestamp + 4'000, matcher._lastMatchedTag.value().second));
-
             expectRangesEquals(
                 std::vector<gr::Tag>{
                     {1, generateTimingTag("EVT_CMD1"s, acqTimestamp + 1'000, 0.0f, true)},
@@ -485,8 +456,6 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
             expect(eq(0uz, result.processedTags));
             expect(eq(0uz, result.processedSamples));
-            expect(eq(false, matcher._lastMatchedTag.has_value()));
-            expect(eq(false, matcher._lastMatchedTag.has_value()));
             expectRangesEquals(std::vector<gr::Tag>{}, result.tags);
         }
     };
@@ -505,8 +474,6 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
         expect(eq(triggerSampleIndices.size(), result.processedTags));
         expect(eq(140uz, result.processedSamples));
-        expect(eq(-38, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 102'000, matcher._lastMatchedTag.value().second));
         expectRangesEquals(
             std::vector<gr::Tag>{
                 {100, generateTimingTag("EVT_CMD1"s, acqTimestamp + 100'000, 0.0f, true)},
@@ -537,8 +504,6 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         auto result = matcher.match(std::span(tags).subspan(0, 2), std::span(triggerSampleIndices).subspan(0, 3), 201uz, std::chrono::nanoseconds(acqTimestamp));
         expect(eq(2uz, result.processedTags));
         expect(eq(191uz, result.processedSamples));
-        expect(eq(-41, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 150'000, matcher._lastMatchedTag.value().second));
         expectRangesEquals(
             std::vector<gr::Tag>{
                 {100, generateTimingTag("EVT_CMD1"s, acqTimestamp + 100'000, 0.0f, true)},
@@ -551,8 +516,6 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         auto result2               = matcher.match(std::span(tags).subspan(2, 3), triggerSampleIndices2, 115uz, std::chrono::nanoseconds(acqTimestamp + static_cast<std::size_t>(191.f * Ts)));
         expect(eq(2uz, result2.processedTags));
         expect(eq(105uz, result2.processedSamples));
-        expect(eq(-46, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 250'000, matcher._lastMatchedTag.value().second));
         expectRangesEquals(
             std::vector<gr::Tag>{
                 {9, generateTimingTag("EVT_CMD3"s, acqTimestamp + 200'000, 0.0f, true)},
@@ -565,98 +528,12 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         auto result3               = matcher.match(std::span(tags).subspan(4, 2), triggerSampleIndices3, 104uz, std::chrono::nanoseconds(acqTimestamp + static_cast<std::size_t>((191.f + 105.f) * Ts)));
         expect(eq(2uz, result3.processedTags));
         expect(eq(94uz, result3.processedSamples));
-        expect(eq(-40, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 350'000, matcher._lastMatchedTag.value().second));
         expectRangesEquals(
             std::vector<gr::Tag>{
                 {4, generateTimingTag("EVT_CMD5"s, acqTimestamp + 300'000, 0.0f, true)},
                 {54, generateTimingTag("EVT_CMD6"s, acqTimestamp + 350'000, 0.0f, true)},
             },
             result3.tags);
-    };
-
-    "sequence of matches"_test = [&] {
-        using namespace boost::ut;
-        using namespace std::chrono_literals;
-
-        constexpr float    sampleRate   = 1e6f; // 1 µs/sample
-        constexpr unsigned nSamples     = 80;   //
-        constexpr auto     timeout      = 10us; // ⇒ maxDelaySamples = 10
-        unsigned long      acqTimestamp = 0;
-
-        TimingMatcher matcher{.timeout = timeout, .sampleRate = sampleRate};
-
-        // 1st match
-        std::vector<gr::property_map> tags1{
-            generateTimingTag("EVT_A"s, acqTimestamp + 10'000, 0.0f, true),
-            generateTimingTag("EVT_B"s, acqTimestamp + 25'000, 0.0f, true),
-        };
-        std::vector<std::size_t> triggerSampleIndices1{10};
-        auto                     result1 = matcher.match(tags1, triggerSampleIndices1, nSamples, std::chrono::nanoseconds(acqTimestamp));
-
-        expect(eq(2uz, result1.processedTags));
-        expect(eq(70uz, result1.processedSamples));
-        expect(eq(-60, matcher._lastMatchedTag.value().first)); // only first tag was matched at index 10
-        expect(eq(acqTimestamp + 10'000, matcher._lastMatchedTag.value().second));
-
-        std::vector<gr::Tag> expectedTags1{
-            {10, generateTimingTag("EVT_A"s, acqTimestamp + 10'000, 0.0f, true)},
-            {25, generateTimingTag("EVT_B"s, acqTimestamp + 25'000, 0.0f, true)},
-        };
-        expectRangesEquals(expectedTags1, result1.tags);
-
-        // 2nd match
-        std::vector<gr::property_map> tags2{
-            generateTimingTag("EVT_C"s, acqTimestamp + 110'000, 0.0f, true),
-            generateTimingTag("EVT_D"s, acqTimestamp + 135'000, 0.0f, false),
-        };
-        std::vector<std::size_t> triggerSampleIndices2{40}; // always local index
-
-        auto result2 = matcher.match(tags2, triggerSampleIndices2, nSamples, std::chrono::nanoseconds(acqTimestamp + 70'000));
-
-        expect(eq(2uz, result2.processedTags));
-        expect(eq(70uz, result2.processedSamples));
-        expect(eq(-30, matcher._lastMatchedTag.value().first)); // only first tag was matched at index 40
-        expect(eq(acqTimestamp + 110'000, matcher._lastMatchedTag.value().second));
-
-        std::vector<gr::Tag> expectedTags2{
-            {40, generateTimingTag("EVT_C"s, acqTimestamp + 110'000, 0.0f, true)},
-            {65, generateTimingTag("EVT_D"s, acqTimestamp + 135'000, 0.0f, false)},
-        };
-        expectRangesEquals(expectedTags2, result2.tags);
-
-        // 3rd match
-        std::vector<gr::property_map> tags3{};
-        std::vector<std::size_t>      triggerSampleIndices3{}; // always local index
-        auto                          result3 = matcher.match(tags3, triggerSampleIndices3, nSamples, std::chrono::nanoseconds(acqTimestamp + 140'000));
-
-        expect(eq(0uz, result3.processedTags));
-        expect(eq(70uz, result3.processedSamples));
-        expect(eq(-100, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 110'000, matcher._lastMatchedTag.value().second));
-
-        std::vector<gr::Tag> expectedTags3{};
-        expectRangesEquals(expectedTags3, result3.tags);
-
-        // 4th match
-        std::vector<gr::property_map> tags4{
-            generateTimingTag("EVT_E"s, acqTimestamp + 220'000, 0.0f, false),
-            generateTimingTag("EVT_F"s, acqTimestamp + 260'000, 0.0f, true),
-        };
-        std::vector<std::size_t> triggerSampleIndices4{50}; // always local index
-
-        auto result4 = matcher.match(tags4, triggerSampleIndices4, nSamples, std::chrono::nanoseconds(acqTimestamp + 210'000));
-
-        expect(eq(2uz, result4.processedTags));
-        expect(eq(70uz, result4.processedSamples));
-        expect(eq(-20, matcher._lastMatchedTag.value().first));
-        expect(eq(acqTimestamp + 260'000, matcher._lastMatchedTag.value().second));
-
-        std::vector<gr::Tag> expectedTags4{
-            {10, generateTimingTag("EVT_E"s, acqTimestamp + 220'000, 0.0f, false)},
-            {50, generateTimingTag("EVT_F"s, acqTimestamp + 260'000, 0.0f, true)},
-        };
-        expectRangesEquals(expectedTags4, result4.tags);
     };
 };
 } // namespace fair::picoscope::test


### PR DESCRIPTION
The PR contains the following changes:
Fix alignTagRelativeToLastMatched: return nullopt if _lastMatchedTag is not set
Revert "TimingMatcher takes into account dropped samples in streaming mode."
Picoscope: fix out of bounds read for picoscope data
 Add diagnostics to TimeMatcher if index of last matched tag  is calculated wrongly.
