### PR TITLE
Docker: update picoscope repository url

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@ RUN sudo apt-get update \
 # while Release.gpg.key still serves the old key — use the stable repo instead
 RUN sudo apt-get update \
     && ( wget -O - https://labs.picotech.com/Release.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/picotech.gpg ) \
-    && ( echo 'deb [signed-by=/usr/share/keyrings/picotech.gpg] https://labs.picotech.com/debian/ picoscope main' | sudo tee /etc/apt/sources.list.d/picoscope.list ) \
+    && ( echo 'deb [signed-by=/usr/share/keyrings/picotech.gpg] https://labs.picotech.com/picoscope7/debian/ picoscope main' | sudo tee /etc/apt/sources.list.d/picoscope.list ) \
     && sudo apt-get update \
     && ( sudo apt-get install -y udev libusb-1.0-0-dev libps3000a libps4000a libps5000a libps6000 libps6000a libx11-dev libgl1-mesa-dev libsdl3-dev || true ) \
     && sudo apt-get clean \


### PR DESCRIPTION
We were still using the old picoscope6 picoscope repo instead of the current one. Additionally remove the workaround for picoscope packaging issue that should be resolved with the new versions.