### PR TITLE
meta: add .zenodo.json and CITATION.cff with verified ORCIDs

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,58 @@
+{
+  "title": "gr-digitizers",
+  "description": "gr-digitizers — GNU Radio blocks for high-speed digitiser hardware.",
+  "license": {
+    "id": "GPL-3.0-only"
+  },
+  "upload_type": "software",
+  "creators": [
+    {
+      "name": "Schwinn, Alexander",
+      "affiliation": "GSI Helmholtzzentrum für Schwerionenforschung"
+    },
+    {
+      "name": "Krimm, Alexander",
+      "affiliation": "GSI Helmholtzzentrum für Schwerionenforschung",
+      "orcid": "0000-0003-0804-756X"
+    },
+    {
+      "name": "Lebedev, Simon",
+      "affiliation": "GSI Helmholtzzentrum für Schwerionenforschung",
+      "orcid": "0009-0006-8329-990X"
+    },
+    {
+      "name": "Osterfeld, Frank",
+      "affiliation": "KDAB"
+    },
+    {
+      "name": "Steinhagen, Ralph J.",
+      "affiliation": "GSI Helmholtzzentrum für Schwerionenforschung / FAIR",
+      "orcid": "0009-0009-8537-7029"
+    },
+    {
+      "name": "Čukić, Ivan",
+      "affiliation": "KDAB",
+      "orcid": "0000-0001-5358-0828"
+    },
+    {
+      "name": "Groß, Magnus",
+      "affiliation": "KDAB"
+    },
+    {
+      "name": "McFarlane, Ian"
+    }
+  ],
+  "keywords": [
+    "digitiser",
+    "GNU Radio",
+    "data acquisition",
+    "accelerator controls"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/fair-acc/gr-digitizers",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,39 @@
+cff-version: 1.2.0
+title: "gr-digitizers"
+message: "If you use this software, please cite it using the metadata from this file."
+type: software
+license: GPL-3.0-only
+repository-code: "https://github.com/fair-acc/gr-digitizers"
+keywords:
+  - digitiser
+  - GNU Radio
+  - data acquisition
+  - accelerator controls
+authors:
+  - family-names: Schwinn
+    given-names: Alexander
+    affiliation: "GSI Helmholtzzentrum für Schwerionenforschung"
+  - family-names: Krimm
+    given-names: Alexander
+    affiliation: "GSI Helmholtzzentrum für Schwerionenforschung"
+    orcid: "https://orcid.org/0000-0003-0804-756X"
+  - family-names: Lebedev
+    given-names: Simon
+    affiliation: "GSI Helmholtzzentrum für Schwerionenforschung"
+    orcid: "https://orcid.org/0009-0006-8329-990X"
+  - family-names: Osterfeld
+    given-names: Frank
+    affiliation: "KDAB"
+  - family-names: Steinhagen
+    given-names: Ralph J.
+    affiliation: "GSI Helmholtzzentrum für Schwerionenforschung / FAIR"
+    orcid: "https://orcid.org/0009-0009-8537-7029"
+  - family-names: Čukić
+    given-names: Ivan
+    affiliation: "KDAB"
+    orcid: "https://orcid.org/0000-0001-5358-0828"
+  - family-names: Groß
+    given-names: Magnus
+    affiliation: "KDAB"
+  - family-names: McFarlane
+    given-names: Ian


### PR DESCRIPTION
## Summary
- Add `.zenodo.json` and `CITATION.cff` for Zenodo DOI minting and GitHub citation support
- 8 contributors; 4 with verified ORCIDs (Krimm, Lebedev, Steinhagen, Čukić)