### PR TITLE
fix(picoscope): preserve pending config updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if(NOT gnuradio4_FOUND)
   FetchContent_Declare(
     gnuradio4
     GIT_REPOSITORY https://github.com/fair-acc/gnuradio4.git
-    GIT_TAG c946b140996efae16486f2118e0faca6f8e52c14 # main as of 2026-04-05
+    GIT_TAG aefb4ad71e47c7ee29e439a18be6e0b380fc711c # main as of 2026-06-17
     EXCLUDE_FROM_ALL)
   list(APPEND GR_DIGITIZER_FETCH_CONTENT_LIST gnuradio4)
 endif()

--- a/blocklib/picoscope/include/fair/picoscope/PicoscopeAPI.hpp
+++ b/blocklib/picoscope/include/fair/picoscope/PicoscopeAPI.hpp
@@ -899,15 +899,14 @@ public:
     [[nodiscard]] const ChannelConfig& getChannelConfig(std::size_t id) const { return channel_config[id].second; };
 
     void configureChannel(std::size_t id, ChannelConfig chan) {
-        bool modified      = channel_config[id].second != chan;
-        channel_config[id] = {modified, chan};
+        const bool modified = channel_config[id].first || channel_config[id].second != chan;
+        channel_config[id]  = {modified, chan};
     }
 
     [[nodiscard]] const TriggerConfig& getTriggerConfig() const { return trigger_config; };
 
     void configureTrigger(TriggerConfig config) {
-        config.modified = trigger_config.modified;
-        config.modified = trigger_config != config;
+        config.modified = trigger_config.modified || trigger_config != config;
         trigger_config  = config;
     }
 


### PR DESCRIPTION
## Summary

  Fix Picoscope pending configuration handling and update the gr-digitizers GR4 test dependency to a newer GR4 revision.

  ## Background

This was found while investigating the **dal009** configuration regression after OD commit `1b05101`, which bumped GR4 from:

  - old GR4: `d14bb560909aaa151b13a535ad4c7f98ad3e9959`
  - new GR4: `f82ba7caec560aec7290be2b6bfae0cbe2aa1847`

  Runtime diagnostics showed that settingsChanged() received the correct logical Picoscope settings, but the hardware channel setup was not applied before streaming started.

  ## Problem

  configureChannel() recalculated the dirty flag only from config inequality:

  channel_config[id].second != chan

  If the same config was submitted again before poll() applied the pending hardware update, the dirty flag could be cleared. Then poll() skipped setChannel(), and streaming started without applying the analog channel configuration.

  configureTrigger() had the same issue.

  ## Fix

  Preserve pending dirty flags when new config is submitted:

  channel_config[id].first || channel_config[id].second != chan
  trigger_config.modified || trigger_config != config

  This keeps pending hardware updates pending until poll() actually applies them.

  ## GR4 Dependency

  Update the gr-digitizers FetchContent GR4 revision from:

  d14bb560909aaa151b13a535ad4c7f98ad3e9959

  to:

  aefb4ad71e47c7ee29e439a18be6e0b380fc711c
