### PR TITLE
Bump gnuradio to after non-owning tag change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if(NOT gnuradio4_FOUND)
   FetchContent_Declare(
     gnuradio4
     GIT_REPOSITORY https://github.com/fair-acc/gnuradio4.git
-    GIT_TAG 2b85bf5cc4978f8260bc23b52cb73d85de0c277b # main as of 2026-06-26
+    GIT_TAG 92278b628c05f01a440cf775fb6cd465c63bab4d # main as of 2026-07-29
     EXCLUDE_FROM_ALL)
   list(APPEND GR_DIGITIZER_FETCH_CONTENT_LIST gnuradio4)
 endif()

--- a/blocklib/picoscope/include/fair/picoscope/Picoscope.hpp
+++ b/blocklib/picoscope/include/fair/picoscope/Picoscope.hpp
@@ -297,7 +297,7 @@ public:
 
         // consume timing tags
         if (matchedTags.processedTags > 0) {
-            auto lastTimingSampleIndex = timingInSpan.rawTags()[matchedTags.processedTags - 1].index - timingInSpan.streamIndex + 1;
+            auto lastTimingSampleIndex = timingInSpan.rawTags()[static_cast<std::int64_t>(matchedTags.processedTags - 1U)].index - timingInSpan.streamIndex + 1;
             timingInSpan.consumeTags(lastTimingSampleIndex);
             std::ignore = timingInSpan.consume(lastTimingSampleIndex);
         } else {

--- a/blocklib/picoscope/include/fair/picoscope/TimingMatcher.hpp
+++ b/blocklib/picoscope/include/fair/picoscope/TimingMatcher.hpp
@@ -6,10 +6,18 @@
 namespace fair::picoscope::timingmatcher {
 using namespace std::chrono_literals;
 
+// owning tag (index + owning map); `gr::Tag` itself is non-owning, so matcher results that outlive their source maps store this instead
+struct MatchedTag {
+    std::size_t      index{0UZ};
+    gr::property_map map{};
+
+    bool operator==(const MatchedTag& other) const = default;
+};
+
 struct MatcherResult {
     std::size_t              processedTags    = 0;
     std::size_t              processedSamples = 0;
-    std::vector<gr::Tag>     tags{};
+    std::vector<MatchedTag>  tags{};
     std::vector<std::string> messages{}; // diagnostic or error messages
 };
 
@@ -61,7 +69,7 @@ struct TimingMatcher {
         return true;
     }
 
-    static gr::Tag createUnknownEventTag(unsigned long index, std::chrono::nanoseconds currentFlankTime) {
+    static MatchedTag createUnknownEventTag(unsigned long index, std::chrono::nanoseconds currentFlankTime) {
         return {index, gr::property_map{
                            {gr::tag::TRIGGER_NAME.shortKey(), "UNKNOWN_EVENT"},
                            // TODO: As for the unmatched trigger only the local time is known, the WR time would have to be realigned based on last_matched_tag
@@ -75,7 +83,7 @@ struct TimingMatcher {
                        }};
     }
 
-    std::optional<gr::Tag> alignTagRelativeToLastMatched(const gr::property_map& currentTag) {
+    std::optional<MatchedTag> alignTagRelativeToLastMatched(const gr::property_map& currentTag) {
         if (!_lastMatchedTag.has_value()) {
             return std::nullopt;
         }
@@ -99,10 +107,10 @@ struct TimingMatcher {
         };
         gr::property_map matchedTag = currentTag;
         matchedTag.insert_or_assign(gr::tag::TRIGGER_OFFSET.shortKey(), deltaOffset);
-        return gr::Tag{static_cast<std::size_t>(idx), matchedTag};
+        return MatchedTag{static_cast<std::size_t>(idx), std::move(matchedTag)};
     }
 
-    gr::Tag getOffsetAdjustedTag(auto currentFlankIndex, auto currentTagOffset, const gr::property_map& tagMap) {
+    MatchedTag getOffsetAdjustedTag(auto currentFlankIndex, auto currentTagOffset, const gr::property_map& tagMap) {
         gr::property_map matchedTagMap = tagMap;
         const float      deltaT        = static_cast<float>(currentTagOffset.count()) * (sampleRate / 1e9f);
         auto             offsetIdx     = static_cast<long>(deltaT);
@@ -112,7 +120,7 @@ struct TimingMatcher {
             offset += 1.0f;
         }
         matchedTagMap.insert_or_assign(gr::tag::TRIGGER_OFFSET.shortKey(), offset);
-        return {static_cast<std::size_t>(static_cast<long>(currentFlankIndex) + offsetIdx), matchedTagMap};
+        return {static_cast<std::size_t>(static_cast<long>(currentFlankIndex) + offsetIdx), std::move(matchedTagMap)};
     }
 
     MatcherResult match(const std::span<const gr::property_map> tags, const std::span<const std::size_t>& triggerSampleIndices, const std::size_t nSamples, const std::chrono::nanoseconds localAcqTime) {
@@ -123,7 +131,7 @@ struct TimingMatcher {
         const auto        maxDelaySamples = static_cast<std::size_t>(static_cast<float>(std::chrono::nanoseconds(timeout).count()) * 1e-9f * sampleRate);
         const std::size_t safeSamples     = nSamples > maxDelaySamples ? nSamples - maxDelaySamples : 0;
         result.processedSamples           = safeSamples; // consume at least all samples up to the deadline
-        auto pushTagOrdered               = [&](gr::Tag&& tag, std::string_view source) {
+        auto pushTagOrdered               = [&](MatchedTag&& tag, std::string_view source) {
             if (!result.tags.empty() && result.tags.back().index > tag.index) {
                 result.messages.emplace_back(std::format("Dropping unordered tag (source={}, newIndex={}, lastIndex={})", source, tag.index, result.tags.back().index));
                 return false;
@@ -176,7 +184,7 @@ struct TimingMatcher {
             if (triggerIndex >= triggerSampleIndices.size()) {                                                                                                                                                                          // there are remaining events, but no more hw edges to match
                 if (!metaMap->find_value("HW-TRIGGER").value_or(gr::pmt::Value{}).holds<bool>() || (currentTagLocalTime + timeout) < (localAcqTime + std::chrono::nanoseconds(static_cast<long>(static_cast<float>(nSamples) * Ts)))) { // we are sure the hw edge cannot still arrive
                     if (_lastMatchedTag) {                                                                                                                                                                                              // publish tags based on last matched trigger
-                        std::optional<gr::Tag> realignedTag = alignTagRelativeToLastMatched(currentTag);
+                        std::optional<MatchedTag> realignedTag = alignTagRelativeToLastMatched(currentTag);
                         if (realignedTag && realignedTag->index >= nSamples) {
                             break; // tag will be moved outside the current data chunk and has to be handled in the next iteration
                         }
@@ -214,7 +222,7 @@ struct TimingMatcher {
             if (!(*maybeHWTrigger) || (currentTagLocalTime + timeout) < currentFlankTime) {
                 // event either explicitly has no hardware trigger or the next hw edge is too far away
                 if (_lastMatchedTag) { // publish tags based on the last-matched trigger // evtB or evt5 in the diagram
-                    if (std::optional<gr::Tag> realignedTag = alignTagRelativeToLastMatched(currentTag)) {
+                    if (std::optional<MatchedTag> realignedTag = alignTagRelativeToLastMatched(currentTag)) {
                         if (realignedTag->index >= nSamples) {
                             break;
                         }
@@ -237,7 +245,7 @@ struct TimingMatcher {
                 continue;
             }
 
-            if (std::optional<gr::Tag> realignedDiagTag = alignTagRelativeToLastMatched(currentTag)) {
+            if (std::optional<MatchedTag> realignedDiagTag = alignTagRelativeToLastMatched(currentTag)) {
                 constexpr std::size_t indexTolerance = 3;
                 if (std::max(realignedDiagTag->index, currentFlankIndex) - std::min(realignedDiagTag->index, currentFlankIndex) > indexTolerance) {
                     result.messages.emplace_back(std::format("Possible wrong matching, lastMatchedTag can be wrongly assigned. Difference between currentTagIndex:{} and currentFlankIndex:{} is more than tolerance ({})", //
@@ -248,7 +256,7 @@ struct TimingMatcher {
             // regular case, next hw edge belongs to the next tag
             _lastMatchedTag = {currentFlankIndex, std::chrono::nanoseconds(currentTagWRTime).count()};
             while (unmatchedEvents > 0) { // align all previously unaligned tags relative to this one
-                if (std::optional<gr::Tag> realignedTag = alignTagRelativeToLastMatched(tags[tagIndex - unmatchedEvents])) {
+                if (std::optional<MatchedTag> realignedTag = alignTagRelativeToLastMatched(tags[tagIndex - unmatchedEvents])) {
                     pushTagOrdered(std::move(*realignedTag), "realign/unmatched-events");
                 } else {
                     result.messages.emplace_back(std::format("Failed to realign tag relative to last matched trigger: {}", currentTag));

--- a/blocklib/picoscope/test/qa_Picoscope.cc
+++ b/blocklib/picoscope/test/qa_Picoscope.cc
@@ -538,17 +538,17 @@ const boost::ut::suite PicoscopeTests = [] {
         auto& clockSrc = flowGraph.emplaceBlock<gr::basic::ClockSource<std::uint8_t>>({{"sample_rate", sampleRate}, {"chunk_size", gr::Size_t{1}}, {"n_samples_max", gr::Size_t{0}}, {"name", "ClockSource"}, {"verbose_console", true}});
 
         clockSrc.tags = {
-            Tag(1000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(1000))), // OK
-            Tag(3000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(3000))), // OK
-            Tag(3500, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(3500))), // This trigger will be ignored
-            Tag(3700, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(3700))), // This trigger will be ignored
-            Tag(5000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(5000))), // This trigger will be disarmed
-            Tag(5500, createTriggerPropertyMap("CMD_BP_STOP", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(5500))),  // disarm trigger
-            Tag(6000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(6000))), // OK
-            Tag(8000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(8000))), // This trigger will be disarmed
-            Tag(8500, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(8500))), // This trigger will be ignored
-            Tag(8700, createTriggerPropertyMap("CMD_BP_STOP", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(8700))),  // disarm trigger
-            Tag(8800, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(8800))), // OK
+            {1000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(1000))}, // OK
+            {3000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(3000))}, // OK
+            {3500, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(3500))}, // This trigger will be ignored
+            {3700, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(3700))}, // This trigger will be ignored
+            {5000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(5000))}, // This trigger will be disarmed
+            {5500, createTriggerPropertyMap("CMD_BP_STOP", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(5500))},  // disarm trigger
+            {6000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(6000))}, // OK
+            {8000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(8000))}, // This trigger will be disarmed
+            {8500, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(8500))}, // This trigger will be ignored
+            {8700, createTriggerPropertyMap("CMD_BP_STOP", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(8700))},  // disarm trigger
+            {8800, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(8800))}, // OK
         }; // disarm trigger
 
         auto& ps = flowGraph.emplaceBlock<Picoscope<T, PicoscopeT>>({
@@ -644,8 +644,8 @@ const boost::ut::suite PicoscopeTests = [] {
         });
 
         clockSrc.tags = {
-            Tag(1000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(1000))), //
-            Tag(6000, createTriggerPropertyMap("CMD_BP_STOP", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(6000))),  // disarm trigger
+            {1000, createTriggerPropertyMap("CMD_BP_START", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(1000))}, //
+            {6000, createTriggerPropertyMap("CMD_BP_STOP", "FAIR.SELECTOR.C=1:S=1:P=1", static_cast<std::uint64_t>(6000))},  // disarm trigger
         };
 
         auto& ps = flowGraph.emplaceBlock<Picoscope<T, PicoscopeT>>({

--- a/blocklib/picoscope/test/qa_PicoscopeTimingHelpers.hpp
+++ b/blocklib/picoscope/test/qa_PicoscopeTimingHelpers.hpp
@@ -183,13 +183,13 @@ void testStreamingWithTiming(const float kSampleRate = 1000.f, const std::chrono
         expect(eq(tag.map.value_or<float>(tag::SIGNAL_MIN.shortKey(), INFINITY), -5.f));
         expect(eq(tag.map.value_or<float>(tag::SIGNAL_MAX.shortKey(), INFINITY), 5.f));
     }
-    expect(std::ranges::equal(sinkA._tags | std::views::filter([](const gr::Tag& t) { return t.map.contains(gr::tag::CONTEXT.shortKey()); })                                                                                                                               // only consider timing events
-                                  | std::views::transform([](const gr::Tag& t) { return t.map.get_if<gr::property_map>(gr::tag::TRIGGER_META_INFO.shortKey()).value_or(gr::property_map{}).value_or<std::uint16_t>("BPID", std::numeric_limits<std::uint16_t>::max()); }), // get bpid (which is unique in this test)
+    expect(std::ranges::equal(sinkA._tags | std::views::filter([](const auto& t) { return t.map.contains(gr::tag::CONTEXT.shortKey()); })                                                                                                                                          // only consider timing events
+                                  | std::views::transform([](const auto& t) { return t.map.template get_if<gr::property_map>(gr::tag::TRIGGER_META_INFO.shortKey()).value_or(gr::property_map{}).template value_or<std::uint16_t>("BPID", std::numeric_limits<std::uint16_t>::max()); }), // get bpid (which is unique in this test)
         std::vector<std::uint16_t>{1, 2, 3}))
         << "expected to get timing events with bpid 1, 2 and 3";
 
     auto chunks = sinkA._tags | std::views::filter([](auto& t) { return t.map.contains("chunk-start-time"); })                                                                                                                                                                                                          //
-                  | std::views::transform([kSampleRate](const gr::Tag& t) { return std::tuple(t.index, static_cast<float>(t.index) * 1e9f / kSampleRate, t.map.value_or<long>("chunk-start-time", std::numeric_limits<long>::max())); })                                                                                //
+                  | std::views::transform([kSampleRate](const auto& t) { return std::tuple(t.index, static_cast<float>(t.index) * 1e9f / kSampleRate, t.map.template value_or<long>("chunk-start-time", std::numeric_limits<long>::max())); })                                                                          //
                   | std::views::pairwise_transform([](const auto& a, const auto& b) { return std::tuple(std::get<0>(b), std::get<0>(b) - std::get<0>(a), std::get<1>(b) - std::get<1>(a), std::get<2>(b) - std::get<2>(a), static_cast<float>(std::get<2>(b) - std::get<2>(a)) - (std::get<1>(b) - std::get<1>(a))); }) // compute chunk durations [index, indexdiff, delta t samples ns, delta t acq ns]
                   | std::ranges::to<std::vector>();
     std::println("Chunks:");
@@ -197,8 +197,8 @@ void testStreamingWithTiming(const float kSampleRate = 1000.f, const std::chrono
         std::println("  - {}: {} samples, {} ns based on sample rate, {} ns between updates", std::get<0>(chunk), std::get<1>(chunk), std::get<2>(chunk), std::get<3>(chunk));
     }
 
-    const std::vector<std::size_t> timingEventSamplesFromTags = std::views::filter(sinkA._tags, [](const gr::Tag& t) { return t.map.contains(gr::tag::CONTEXT.shortKey()); }) // only consider timing events
-                                                                | std::views::transform([](const gr::Tag& t) { return t.index; })                                             // get tag index
+    const std::vector<std::size_t> timingEventSamplesFromTags = std::views::filter(sinkA._tags, [](const auto& t) { return t.map.contains(gr::tag::CONTEXT.shortKey()); }) // only consider timing events
+                                                                | std::views::transform([](const auto& t) { return t.index; })                                             // get tag index
                                                                 | std::ranges::to<std::vector>();
     const std::vector detectedEdges        = std::views::zip(std::views::iota(0U), sinkD._samples) | std::views::filter([](const auto& p) { return std::get<1>(p) > 1.7f; }) | std::views::transform([](const auto& p) { return std::get<0>(p); }) | std::ranges::to<std::vector>();
     const std::vector detectedEdgesDigital = std::views::zip(std::views::iota(0U), sinkDigital._samples) | std::views::filter([](const auto& p) { return (std::get<1>(p) & (1u << 4)); }) | std::views::transform([](const auto& p) { return std::get<0>(p); }) | std::ranges::to<std::vector>();

--- a/blocklib/picoscope/test/qa_TimingMatcher.cc
+++ b/blocklib/picoscope/test/qa_TimingMatcher.cc
@@ -6,14 +6,14 @@ using namespace std::string_literals;
 using namespace std::chrono_literals;
 
 template<>
-struct std::formatter<gr::Tag> {
+struct std::formatter<fair::picoscope::timingmatcher::MatchedTag> {
     template<typename ParseContext>
     constexpr auto parse(ParseContext& ctx) {
         return ctx.begin();
     }
 
     template<typename FormatContext>
-    constexpr auto format(const gr::Tag& tag, FormatContext& ctx) const {
+    constexpr auto format(const fair::picoscope::timingmatcher::MatchedTag& tag, FormatContext& ctx) const {
         return std::format_to(ctx.out(), "  {}->{{ {} }}\n", tag.index, tag.map);
     }
 };
@@ -61,7 +61,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         expect(eq(triggerSampleIndices.size(), result.processedTags));
         expect(eq(240UZ, result.processedSamples));
         expectRangesEquals(
-            std::vector<gr::Tag>{
+            std::vector<timingmatcher::MatchedTag>{
                 {100, generateTimingTag("EVT_CMD1"s, acqTimestamp + 100'000, 0.0f, true)},
                 {150, generateTimingTag("EVT_CMD2"s, acqTimestamp + 150'000, 0.0f, true)},
                 {200, generateTimingTag("EVT_CMD3"s, acqTimestamp + 200'000, 0.0f, true)},
@@ -86,7 +86,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         expect(eq(5UZ, result.processedTags));
         expect(eq(240UZ, result.processedSamples));
         expectRangesEquals(
-            std::vector<gr::Tag>{
+            std::vector<timingmatcher::MatchedTag>{
                 {100, generateTimingTag("EVT_CMD1"s, acqTimestamp + 100'000, 0.0f, true)},
                 {150, generateTimingTag("EVT_CMD2A"s, acqTimestamp + 150'000, 0.0f, true)},
                 {150, generateTimingTag("EVT_CMD2B"s, acqTimestamp + 150'000, 0.0f, true)},
@@ -113,7 +113,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         expect(eq(5UZ, result.processedTags));
         expect(eq(240UZ, result.processedSamples));
         expectRangesEquals(
-            std::vector<gr::Tag>{
+            std::vector<timingmatcher::MatchedTag>{
                 {100UZ, generateTimingTag("EVT_CMD1"s, acqTimestamp + 100'000, 0.0f, true)},
                 {150UZ, generateTimingTag("EVT_CMD2A"s, acqTimestamp + 150'000, 0.0f, false)},
                 {150UZ, generateTimingTag("EVT_CMD2B"s, acqTimestamp + 150'000, 0.0f, true)},
@@ -140,7 +140,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         expect(eq(5UZ, result.processedTags));
         expect(eq(240UZ, result.processedSamples));
         expectRangesEquals(
-            std::vector<gr::Tag>{
+            std::vector<timingmatcher::MatchedTag>{
                 {100UZ, generateTimingTag("EVT_CMD1", acqTimestamp + 100'000, 0.0f, true)},
                 {150UZ, generateTimingTag("EVT_CMD2", acqTimestamp + 150'000, 0.0f, true)},
                 {200UZ, generateTimingTag("EVT_CMD3", acqTimestamp + 200'000, 0.0f, true)},
@@ -162,7 +162,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
         expect(eq(3UZ, result.processedTags));
         expect(eq(1'240UZ, result.processedSamples));
-        std::vector<gr::Tag> expected{
+        std::vector<timingmatcher::MatchedTag> expected{
             {100, generateUnknownTag("UNKNOWN_EVENT", acqTimestamp + 100'000, 0.0f, false)},
             {150, generateUnknownTag("UNKNOWN_EVENT", acqTimestamp + 150'000, 0.0f, false)},
             {200, generateUnknownTag("UNKNOWN_EVENT", acqTimestamp + 200'000, 0.0f, false)},
@@ -192,7 +192,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         result.tags[2].map.insert_or_assign(gr::tag::TRIGGER_OFFSET.shortKey(), 0.0f);
 
         expectRangesEquals(
-            std::vector<gr::Tag>{
+            std::vector<timingmatcher::MatchedTag>{
                 {100, generateTimingTag("EVT_CMD1", acqTimestamp + 100'000, 0.0f, true)},
                 {150, generateTimingTag("EVT_CMD2", acqTimestamp + 150'000, 0.0f, true)},
                 {151, generateTimingTag("EVT_CMD2b", acqTimestamp + 151'000, 0.0f, true)},
@@ -218,7 +218,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         expect(eq(240UZ, result.processedSamples));
 
         expectRangesEquals(
-            std::vector<gr::Tag>{
+            std::vector<timingmatcher::MatchedTag>{
                 {100, generateTimingTag("EVT_CMD1", acqTimestamp + 100'000, 0.0f, true)},
                 {150, generateTimingTag("EVT_CMD2", acqTimestamp + 150'000, 0.0f, true)},
                 {150, generateTimingTag("EVT_CMD2b", acqTimestamp + 150'000, 0.0f, true)},
@@ -244,7 +244,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         expect(eq(240UZ, result.processedSamples));
 
         expectRangesEquals(
-            std::vector<gr::Tag>{
+            std::vector<timingmatcher::MatchedTag>{
                 {100, generateTimingTag("EVT_CMD1", acqTimestamp + 100'000, 0.0f, true)},
                 {150, generateTimingTag("EVT_CMD2", acqTimestamp + 150'000, 0.0f, true)},
                 {180, generateTimingTag("EVT_CMDA", acqTimestamp + 180'000, 0.0f, false)},
@@ -270,7 +270,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         expect(eq(240UZ, result.processedSamples));
 
         expectRangesEquals(
-            std::vector<gr::Tag>{
+            std::vector<timingmatcher::MatchedTag>{
                 {100, generateTimingTag("EVT_CMD1", acqTimestamp + 100'000, 0.0f, true)},
                 {150, generateTimingTag("EVT_CMD2", acqTimestamp + 150'000, 0.0f, true)},
                 {180, generateTimingTag("EVT_CMDA", acqTimestamp + 180'000, 0.0f, true)},
@@ -298,7 +298,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
             std::println(" - {}", msg);
         }
         expectRangesEquals(
-            std::vector<gr::Tag>{
+            std::vector<timingmatcher::MatchedTag>{
                 {100, generateTimingTag("EVT_CMD1", acqTimestamp + 100'000, 0.0f, true)},
                 {150, generateTimingTag("EVT_CMD2", acqTimestamp + 150'000, 0.0f, true)},
                 {200, generateTimingTag("EVT_CMD3", acqTimestamp + 200'000, 0.0f, true)},
@@ -324,7 +324,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         expect(eq(240UZ, result.processedSamples));
 
         expectRangesEquals(
-            std::vector<gr::Tag>{
+            std::vector<timingmatcher::MatchedTag>{
                 {100, generateTimingTag("EVT_CMD1", wrTimestamp + 100'000, 0.0f, true, acqTimestamp + 100'000)},
                 {150, generateTimingTag("EVT_CMD2", wrTimestamp + 150'000, 0.0f, true, acqTimestamp + 150'000)},
                 {200, generateTimingTag("EVT_CMD3", wrTimestamp + 200'000, 0.0f, true, acqTimestamp + 200'000)},
@@ -350,7 +350,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         expect(eq(240UZ, result.processedSamples));
 
         expectRangesEquals(
-            std::vector<gr::Tag>{
+            std::vector<timingmatcher::MatchedTag>{
                 {100, generateTimingTag("EVT_CMD1", acqTimestamp + 100'000, 0.0f, true)},
                 {150, generateTimingTag("EVT_CMD2", acqTimestamp + 150'000, 0.0f, true)},
                 {200, generateTimingTag("EVT_CMD3", acqTimestamp + 200'000, 0.0f, true)},
@@ -386,7 +386,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         result.tags[2].map.insert_or_assign(gr::tag::TRIGGER_OFFSET.shortKey(), 0.0f);
 
         expectRangesEquals(
-            std::vector<gr::Tag>{
+            std::vector<timingmatcher::MatchedTag>{
                 {100, generateTimingTag("EVT_CMD1", acqTimestamp + 100'000, 0.f, true, acqTimestamp + 101'000)},
                 {150, generateTimingTag("EVT_CMD2", acqTimestamp + 150'000, 0.f, true, acqTimestamp + 170'000)},
                 {199, generateTimingTag("EVT_CMD3", acqTimestamp + 200'000, 0.f, true, acqTimestamp + 200'000)},
@@ -412,7 +412,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
                 std::println(" - {}", msg);
             }
             expectRangesEquals(
-                std::vector<gr::Tag>{
+                std::vector<timingmatcher::MatchedTag>{
                     {100, generateUnknownTag("UNKNOWN_EVENT", acqTimestamp + 100'000, 0.0f, false)},
                     {150, generateUnknownTag("UNKNOWN_EVENT", acqTimestamp + 150'000, 0.0f, false)},
                     {200, generateUnknownTag("UNKNOWN_EVENT", acqTimestamp + 200'000, 0.0f, false)},
@@ -424,14 +424,14 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
             auto          result = matcher.match(tags, std::vector<std::size_t>{}, 250UZ, std::chrono::nanoseconds(acqTimestamp));
             expect(eq(result.processedTags, 3UZ));
             expect(eq(result.processedSamples, 240UZ));
-            expectRangesEquals(std::vector<gr::Tag>{}, result.tags);
+            expectRangesEquals(std::vector<timingmatcher::MatchedTag>{}, result.tags);
         }
         { // empty hw edge list
             TimingMatcher matcher{.timeout = 10us, .sampleRate = 1e6f};
             auto          result = matcher.match(std::vector<gr::property_map>{}, std::vector<std::size_t>{}, 250UZ, std::chrono::nanoseconds(acqTimestamp));
             expect(eq(result.processedTags, 0UZ));
             expect(eq(result.processedSamples, 240UZ));
-            expectRangesEquals(std::vector<gr::Tag>{}, result.tags);
+            expectRangesEquals(std::vector<timingmatcher::MatchedTag>{}, result.tags);
         }
     };
 
@@ -450,7 +450,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
             expect(eq(2UZ, result.processedTags));
             expect(eq(4UZ, result.processedSamples)); // processed up to the last matching tag
             expectRangesEquals(
-                std::vector<gr::Tag>{
+                std::vector<timingmatcher::MatchedTag>{
                     {1, generateTimingTag("EVT_CMD1"s, acqTimestamp + 1'000, 0.0f, true)},
                     {4, generateTimingTag("EVT_CMD3"s, acqTimestamp + 4'000, 0.0f, true)},
                 },
@@ -462,7 +462,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
 
             expect(eq(0UZ, result.processedTags));
             expect(eq(0UZ, result.processedSamples));
-            expectRangesEquals(std::vector<gr::Tag>{}, result.tags);
+            expectRangesEquals(std::vector<timingmatcher::MatchedTag>{}, result.tags);
         }
     };
 
@@ -481,7 +481,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         expect(eq(triggerSampleIndices.size(), result.processedTags));
         expect(eq(140UZ, result.processedSamples));
         expectRangesEquals(
-            std::vector<gr::Tag>{
+            std::vector<timingmatcher::MatchedTag>{
                 {100, generateTimingTag("EVT_CMD1"s, acqTimestamp + 100'000, 0.0f, true)},
                 {101, generateTimingTag("EVT_CMD2"s, acqTimestamp + 101'000, 0.0f, true)},
                 {102, generateTimingTag("EVT_CMD3"s, acqTimestamp + 102'000, 0.0f, true)},
@@ -511,7 +511,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         expect(eq(2UZ, result.processedTags));
         expect(eq(191UZ, result.processedSamples));
         expectRangesEquals(
-            std::vector<gr::Tag>{
+            std::vector<timingmatcher::MatchedTag>{
                 {100, generateTimingTag("EVT_CMD1"s, acqTimestamp + 100'000, 0.0f, true)},
                 {150, generateTimingTag("EVT_CMD2"s, acqTimestamp + 150'000, 0.0f, true)},
             },
@@ -523,7 +523,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         expect(eq(2UZ, result2.processedTags));
         expect(eq(105UZ, result2.processedSamples));
         expectRangesEquals(
-            std::vector<gr::Tag>{
+            std::vector<timingmatcher::MatchedTag>{
                 {9, generateTimingTag("EVT_CMD3"s, acqTimestamp + 200'000, 0.0f, true)},
                 {59, generateTimingTag("EVT_CMD4"s, acqTimestamp + 250'000, 0.0f, true)},
             },
@@ -535,7 +535,7 @@ const boost::ut::suite<"TimingMatchers"> TimingMatcherTests = [] {
         expect(eq(2UZ, result3.processedTags));
         expect(eq(94UZ, result3.processedSamples));
         expectRangesEquals(
-            std::vector<gr::Tag>{
+            std::vector<timingmatcher::MatchedTag>{
                 {4, generateTimingTag("EVT_CMD5"s, acqTimestamp + 300'000, 0.0f, true)},
                 {54, generateTimingTag("EVT_CMD6"s, acqTimestamp + 350'000, 0.0f, true)},
             },

--- a/blocklib/timing/include/fair/timing/TimingSource.hpp
+++ b/blocklib/timing/include/fair/timing/TimingSource.hpp
@@ -389,10 +389,10 @@ tags: [
         }
     }
 
-    static void addHwTriggerInfo(const std::uint64_t id, Tag& tag, const std::vector<std::tuple<std::uint64_t, std::uint64_t>>& eventMeta) {
-        auto metaMapIterator = tag.map.find(gr::tag::TRIGGER_META_INFO.shortKey());
-        if (metaMapIterator == std::end(tag.map) || metaMapIterator->second.is_monostate()) {
-            metaMapIterator = tag.map.insert_or_assign(gr::tag::TRIGGER_META_INFO.shortKey(), gr::property_map{}).first;
+    static void addHwTriggerInfo(const std::uint64_t id, gr::property_map& tagMap, const std::vector<std::tuple<std::uint64_t, std::uint64_t>>& eventMeta) {
+        auto metaMapIterator = tagMap.find(gr::tag::TRIGGER_META_INFO.shortKey());
+        if (metaMapIterator == std::end(tagMap) || metaMapIterator->second.is_monostate()) {
+            metaMapIterator = tagMap.insert_or_assign(gr::tag::TRIGGER_META_INFO.shortKey(), gr::property_map{}).first;
         } else if (!metaMapIterator->second.is_map()) {
             return; // edge case where the tag map already contains data of a non-map type on the meta-info key -> just skip adding metadata
         }
@@ -406,16 +406,16 @@ tags: [
             }
         }
         metaMapCopy.insert_or_assign("HW-TRIGGER", isHwTrigger);
-        tag.map.insert_or_assign(gr::tag::TRIGGER_META_INFO.shortKey(), std::move(metaMapCopy));
+        tagMap.insert_or_assign(gr::tag::TRIGGER_META_INFO.shortKey(), std::move(metaMapCopy));
     }
 
-    void addHwTriggerInfo(const std::uint64_t id, Tag& tag) const { addHwTriggerInfo(id, tag, eventHwTrigger); }
+    void addHwTriggerInfo(const std::uint64_t id, gr::property_map& tagMap) const { addHwTriggerInfo(id, tagMap, eventHwTrigger); }
 
-    Tag eventToTag(const Timing::Event& event, const std::int64_t currentTime) {
-        Tag              tag;
+    gr::property_map eventToTagMap(const Timing::Event& event, const std::int64_t currentTime) {
+        gr::property_map tagMap;
         gr::property_map meta;
         std::uint64_t    id = event.id();
-        tag.map.emplace(tag::TRIGGER_TIME.shortKey(), taiNsToUtcNs(event.time));
+        tagMap.emplace(tag::TRIGGER_TIME.shortKey(), taiNsToUtcNs(event.time));
         meta.emplace("LOCAL-TIME", static_cast<std::uint64_t>(currentTime));
         meta.emplace("TIMING-ID", id);
         meta.emplace("TIMING-PARAM", event.param());
@@ -424,8 +424,8 @@ tags: [
             std::string ioName = _timing.idToIoName(id);
             meta.emplace("IO-NAME", ioName);
             meta.emplace("IO-LEVEL", level);
-            tag.map.emplace(tag::TRIGGER_NAME.shortKey(), std::format("{}_{}", ioName, level ? "RISING" : "FALLING"));
-            tag.map.emplace(tag::TRIGGER_OFFSET.shortKey(), 0.0f);
+            tagMap.emplace(tag::TRIGGER_NAME.shortKey(), std::format("{}_{}", ioName, level ? "RISING" : "FALLING"));
+            tagMap.emplace(tag::TRIGGER_OFFSET.shortKey(), 0.0f);
         } else {
             meta.emplace("GID", event.gid);
             if (timingGroupTable.contains(event.gid)) {
@@ -442,18 +442,18 @@ tags: [
                 }
             }();
             meta.emplace("EVENT-NAME", eventName);
-            tag.map.emplace(tag::TRIGGER_NAME.shortKey(), eventName);
-            tag.map.emplace(tag::CONTEXT.shortKey(), std::format("FAIR-TIMING:C={}.S={}.P={}.T={}", event.bpcid, event.sid, event.bpid, event.gid));
+            tagMap.emplace(tag::TRIGGER_NAME.shortKey(), eventName);
+            tagMap.emplace(tag::CONTEXT.shortKey(), std::format("FAIR-TIMING:C={}.S={}.P={}.T={}", event.bpcid, event.sid, event.bpid, event.gid));
             meta.emplace("BPCTS", event.bpcts); // chain execution time-stamp (i.e. unique chain identifier)
             meta.emplace("BPCID", event.bpcid); // chain ID (can contain multiple sequences)
             meta.emplace("SID", event.sid);     // chain ID -> sequence ID (can contain multiple beam-processes)
             meta.emplace("BPID", event.bpid);   // beam process ID (PID)
             meta.emplace("BEAM-IN", event.flagBeamin);
             meta.emplace("BPC-START", event.flagBpcStart);
-            tag.map.emplace(tag::TRIGGER_OFFSET.shortKey(), 0.0f); // The trigger offset has to be set either when publishing at fixed sample rate or when adding the tag to a sample e.g. in the picoscope block
+            tagMap.emplace(tag::TRIGGER_OFFSET.shortKey(), 0.0f); // The trigger offset has to be set either when publishing at fixed sample rate or when adding the tag to a sample e.g. in the picoscope block
         }
-        tag.map.emplace(tag::TRIGGER_META_INFO.shortKey(), meta);
-        return tag;
+        tagMap.emplace(tag::TRIGGER_META_INFO.shortKey(), meta);
+        return tagMap;
     }
 
     void updateOutputState(const Timing::Event& event) {
@@ -473,8 +473,8 @@ tags: [
         std::size_t  toPublish   = 0;
         std::int64_t currentTime = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
         for (const Timing::Event& event : timingEvents) {
-            gr::Tag timingTag = eventToTag(event, currentTime);
-            addHwTriggerInfo(event.id(), timingTag);
+            gr::property_map timingTagMap = eventToTagMap(event, currentTime);
+            addHwTriggerInfo(event.id(), timingTagMap);
             // TODO: make stable against rounding errors by using global time difference instead of just between 2 events
             std::size_t samplesUntilCurrentEvent = 0;
             if (sample_rate != 0.0f) {
@@ -499,7 +499,7 @@ tags: [
                 const std::size_t taggedSampleAbs                 = _publishedSamples + toPublish - 1;
                 const auto        taggedSampleNs                  = static_cast<std::int64_t>(static_cast<double>(taggedSampleAbs) / static_cast<double>(sample_rate) * 1e9);
                 const auto        offsetNs                        = std::max<std::int64_t>(0, eventDeltaNs - taggedSampleNs);
-                timingTag.map[gr::tag::TRIGGER_OFFSET.shortKey()] = static_cast<std::uint64_t>(offsetNs);
+                timingTagMap[gr::tag::TRIGGER_OFFSET.shortKey()] = static_cast<std::uint64_t>(offsetNs);
             } else { // sample_rate == 0.0f -> publish one sample per timing tag
                 samplesUntilCurrentEvent = 1;
                 if (_nextOutputState != _outputState) {
@@ -513,9 +513,9 @@ tags: [
                 updateOutputState(event);
                 outSpan[toPublish - 1] = _outputState + 1;
             }
-            outSpan.publishTag(timingTag.map, toPublish - 1);
+            outSpan.publishTag(timingTagMap, toPublish - 1);
             if (verbose_console) {
-                std::print("publishing tag, localtime: {}, {} samples before, then sample with tag {}\n", currentTime, samplesUntilCurrentEvent, timingTag.map);
+                std::print("publishing tag, localtime: {}, {} samples before, then sample with tag {}\n", currentTime, samplesUntilCurrentEvent, timingTagMap);
             }
         }
 

--- a/blocklib/timing/test/qa_timingSource.cpp
+++ b/blocklib/timing/test/qa_timingSource.cpp
@@ -64,16 +64,16 @@ const suite TimingBlockHelpers = [] {
             {0x112d100000000000ul, 0xfffffff000000000ul},
         };
         { // id does not match any filters -> HW-TRIGGER: false
-            gr::Tag tag{0uz, {{"existingKey", "test"}}};
-            gr::timing::TimingSource::addHwTriggerInfo(0x1136200000000000ul, tag, actionTrigger);
+            gr::property_map tagMap{{"existingKey", "test"}};
+            gr::timing::TimingSource::addHwTriggerInfo(0x1136200000000000ul, tagMap, actionTrigger);
             gr::property_map expected{{"existingKey", "test"}, {gr::tag::TRIGGER_META_INFO.shortKey(), gr::property_map{{"HW-TRIGGER", false}}}};
-            expect(std::ranges::equal(expected, tag.map)) << [&tag, &expected]() { return std::format("got: {} exp: {}", tag.map, expected); };
+            expect(std::ranges::equal(expected, tagMap)) << [&tagMap, &expected]() { return std::format("got: {} exp: {}", tagMap, expected); };
         }
         { // id matches first filter in the filter list -> HW-TRIGGER: true
-            gr::Tag tag{0uz, {{"existingKey", "test"}}};
-            gr::timing::TimingSource::addHwTriggerInfo(0x1136100000000000ul, tag, actionTrigger);
+            gr::property_map tagMap{{"existingKey", "test"}};
+            gr::timing::TimingSource::addHwTriggerInfo(0x1136100000000000ul, tagMap, actionTrigger);
             gr::property_map expected{{"existingKey", "test"}, {gr::tag::TRIGGER_META_INFO.shortKey(), gr::property_map{{"HW-TRIGGER", true}}}};
-            expect(std::ranges::equal(expected, tag.map)) << [&tag, &expected]() { return std::format("got: {} exp: {}", tag.map, expected); };
+            expect(std::ranges::equal(expected, tagMap)) << [&tagMap, &expected]() { return std::format("got: {} exp: {}", tagMap, expected); };
         }
     };
 };
@@ -130,8 +130,8 @@ std::thread dispatchSimulatedTiming(std::size_t n = 30, std::size_t schedule_dt 
 const suite TimingBlock = [] {
     // boost::ext::ut::cfg<override> = {.tag = {"timing-hardware"}};
 
-    constexpr static auto getBPID = [](gr::Tag& tag) -> std::optional<uint16_t> {
-        auto BPIDValue = tag.map.get_if<gr::property_map>(gr::tag::TRIGGER_META_INFO.shortKey()).value_or(gr::property_map{}).find_value("BPID").value_or(gr::pmt::Value{});
+    constexpr static auto getBPID = [](const auto& tag) -> std::optional<uint16_t> {
+        auto BPIDValue = tag.map.template get_if<gr::property_map>(gr::tag::TRIGGER_META_INFO.shortKey()).value_or(gr::property_map{}).find_value("BPID").value_or(gr::pmt::Value{});
         assert(BPIDValue.template holds<uint16_t>());
         return BPIDValue.value_or(uint16_t{});
     };
@@ -194,7 +194,7 @@ const suite TimingBlock = [] {
 
         expect(approx(sink._samples.size(), 60000UZ, 1000UZ)) << "samples do not approximately correspond to the configured sample rate";
         expect(approx(sink._tags.size(), 50UZ, 10UZ)) << "expected approximately 50 tags";
-        expect(std::ranges::equal(sink._tags | std::views::filter([](const gr::Tag& tag) { return tag.map.contains(gr::tag::TRIGGER_META_INFO.shortKey()) && tag.map.get_if<gr::property_map>(gr::tag::TRIGGER_META_INFO.shortKey()).value_or(gr::property_map{}).contains("BPID"); }) | std::views::transform(getBPID), std::array{0, 6, 12, 18, 24})) << "Did not receive the correct timing tags with the correct BP indices";
+        expect(std::ranges::equal(sink._tags | std::views::filter([](const auto& tag) { return tag.map.contains(gr::tag::TRIGGER_META_INFO.shortKey()) && tag.map.template get_if<gr::property_map>(gr::tag::TRIGGER_META_INFO.shortKey()).value_or(gr::property_map{}).contains("BPID"); }) | std::views::transform(getBPID), std::array{0, 6, 12, 18, 24})) << "Did not receive the correct timing tags with the correct BP indices";
 
         expect(std::ranges::equal(sink._samples | std::views::transform([](auto v) { return v >> 2; })                                    // drop irrelevant bits (LSB: tagPresent, LSB+1:output which toggles on timing events)
                                       | std::views::chunk_by(std::equal_to{})                                                             // merge and count identical samples
@@ -248,7 +248,7 @@ const suite TimingBlock = [] {
 
         expect(eq(sink._samples.size(), sink._tags.size())) << "For sample_rate=0.0f the number of samples and tags should be identical";
         expect(approx(sink._tags.size(), 60UZ, 10UZ)) << "Expected approximately 60 tags";
-        expect(std::ranges::equal(sink._tags | std::views::filter([](gr::Tag& tag) { return tag.map.contains(gr::tag::TRIGGER_META_INFO.shortKey()) && tag.map.get_if<gr::property_map>(gr::tag::TRIGGER_META_INFO.shortKey()).value_or(gr::property_map{}).contains("BPID"); }) | std::views::transform(getBPID), std::array{0, 6, 12, 18, 24})) << "Did not receive the correct timing tags with the correct BP indices";
+        expect(std::ranges::equal(sink._tags | std::views::filter([](const auto& tag) { return tag.map.contains(gr::tag::TRIGGER_META_INFO.shortKey()) && tag.map.template get_if<gr::property_map>(gr::tag::TRIGGER_META_INFO.shortKey()).value_or(gr::property_map{}).contains("BPID"); }) | std::views::transform(getBPID), std::array{0, 6, 12, 18, 24})) << "Did not receive the correct timing tags with the correct BP indices";
         std::size_t nIO = 0;
         for (const auto& [sample, tag] : std::views::zip(sink._samples, sink._tags)) {
             if (tag.map.contains(tag::TRIGGER_META_INFO.shortKey())) {


### PR DESCRIPTION
In order to deal with the tags being non-owning, this basically reimplements `testing::OwningTag`.

**Edit** closing this, I forgot that Ivan has a change for this in flight. And I (nor AI) do not understand digitizer things so it is certainly better :D